### PR TITLE
Added native schema support to SqlParser

### DIFF
--- a/frictionless/header.py
+++ b/frictionless/header.py
@@ -1,5 +1,6 @@
 from itertools import zip_longest
 from .helpers import cached_property
+from . import helpers
 from . import errors
 
 
@@ -57,7 +58,10 @@ class Header(list):
                             field_name=field.name,
                             field_number=field_number,
                             field_position=field_position
-                            or max(field_positions) + field_number - start + 1,
+                            or helpers.safe_max(field_positions)
+                            + field_number
+                            - start
+                            + 1,
                         )
                     )
 

--- a/frictionless/header.py
+++ b/frictionless/header.py
@@ -1,6 +1,5 @@
 from itertools import zip_longest
 from .helpers import cached_property
-from . import helpers
 from . import errors
 
 
@@ -58,10 +57,7 @@ class Header(list):
                             field_name=field.name,
                             field_number=field_number,
                             field_position=field_position
-                            or helpers.safe_max(field_positions)
-                            + field_number
-                            - start
-                            + 1,
+                            or max(field_positions, default=0) + field_number - start + 1,
                         )
                     )
 

--- a/frictionless/helpers.py
+++ b/frictionless/helpers.py
@@ -7,7 +7,6 @@ import chardet
 import tempfile
 import datetime
 import stringcase
-from copy import deepcopy
 from pprint import pformat
 from tabulate import tabulate
 from inspect import signature
@@ -285,12 +284,6 @@ class ControlledDict(dict):
         if onchange:
             onchange(self) if signature(onchange).parameters else onchange()
 
-    def __copy__(self, *args, **kwargs):
-        return self.__deepcopy__()
-
-    def __deepcopy__(self, *args, **kwargs):
-        return {key: deepcopy(value, *args, **kwargs) for key, value in self.items()}
-
     def __setitem__(self, *args, **kwargs):
         result = super().__setitem__(*args, **kwargs)
         self.__onchange__()
@@ -305,9 +298,6 @@ class ControlledDict(dict):
         result = super().clear(*args, **kwargs)
         self.__onchange__()
         return result
-
-    def copy(self, *args, **kwargs):
-        return self.__copy__(*args, **kwargs)
 
     def pop(self, *args, **kwargs):
         result = super().pop(*args, **kwargs)
@@ -339,12 +329,6 @@ class ControlledList(list):
         if onchange:
             onchange(self) if signature(onchange).parameters else onchange()
 
-    def __copy__(self, *args, **kwargs):
-        return self.__deepcopy__()
-
-    def __deepcopy__(self, *args, **kwargs):
-        return [deepcopy(value, *args, **kwargs) for value in self]
-
     def __setitem__(self, *args, **kwargs):
         result = super().__setitem__(*args, **kwargs)
         self.__onchange__()
@@ -364,9 +348,6 @@ class ControlledList(list):
         result = super().clear(*args, **kwargs)
         self.__onchange__()
         return result
-
-    def copy(self, *args, **kwargs):
-        return self.__copy__(*args, **kwargs)
 
     def extend(self, *args, **kwargs):
         result = super().extend(*args, **kwargs)

--- a/frictionless/helpers.py
+++ b/frictionless/helpers.py
@@ -42,6 +42,12 @@ def pass_through(iterator):
         pass
 
 
+def safe_max(value):
+    if not value:
+        return 0
+    return max(value)
+
+
 def import_from_plugin(name, *, plugin):
     try:
         return import_module(name)
@@ -84,12 +90,12 @@ def tabulate_metadata(metadata):
     return tabulate(content, headers=headers)
 
 
-def detect_name(path):
-    if not path:
-        return "memory"
-    file = os.path.basename(path)
-    name = os.path.splitext(file)[0]
-    return name
+def detect_name(source):
+    if isinstance(source, str):
+        return os.path.splitext(os.path.basename(source))[0]
+    if isinstance(source, list) and source and isinstance(source[0], str):
+        return os.path.splitext(os.path.basename(source[0]))[0]
+    return "memory"
 
 
 def detect_basepath(descriptor):
@@ -99,24 +105,6 @@ def detect_basepath(descriptor):
         if basepath and not is_remote_path(basepath):
             basepath = os.path.relpath(basepath, start=os.getcwd())
     return basepath
-
-
-def detect_path_and_data(source):
-    if not source:
-        return [None, None]
-    elif isinstance(source, str):
-        return [source, None]
-    elif isinstance(source, list) and isinstance(source[0], str):
-        return [source, None]
-    return [None, source]
-
-
-def detect_path(source):
-    return detect_path_and_data(source)[0]
-
-
-def detect_data(source):
-    return detect_path_and_data(source)[1]
 
 
 def ensure_dir(path):

--- a/frictionless/helpers.py
+++ b/frictionless/helpers.py
@@ -42,12 +42,6 @@ def pass_through(iterator):
         pass
 
 
-def safe_max(value):
-    if not value:
-        return 0
-    return max(value)
-
-
 def import_from_plugin(name, *, plugin):
     try:
         return import_module(name)

--- a/frictionless/location.py
+++ b/frictionless/location.py
@@ -4,6 +4,8 @@ from . import helpers
 from . import config
 
 
+# TODO: Normalize detection functions
+# TODO: Merge into Resource when MultipartSource is moved?
 class Location:
     def __init__(self, resource):
 
@@ -21,6 +23,7 @@ class Location:
             source = MultipartSource(resource.path, basepath=basepath, headless=headless)
 
         # Detect scheme/format/compression/compression_path
+        name = helpers.detect_name(source)
         detect = helpers.detect_source_scheme_and_format(source)
         compression = config.DEFAULT_COMPRESSION
         compression_path = config.DEFAULT_COMPRESSION_PATH
@@ -34,11 +37,16 @@ class Location:
         format = detect[1] or config.DEFAULT_FORMAT
 
         # Set attributes
+        self.__name = name
         self.__source = source
         self.__scheme = scheme
         self.__format = format
         self.__compression = compression
         self.__compression_path = compression_path
+
+    @property
+    def name(self):
+        return self.__name
 
     @property
     def source(self):

--- a/frictionless/location.py
+++ b/frictionless/location.py
@@ -11,7 +11,7 @@ class Location:
 
         # Detect source
         source = []
-        if resource.data:
+        if resource.data is not None:
             source = resource.data
         elif isinstance(resource.path, str):
             source = resource.path

--- a/frictionless/metadata.py
+++ b/frictionless/metadata.py
@@ -82,6 +82,14 @@ class Metadata(helpers.ControlledDict):
 
     # Import/Export
 
+    def to_copy(self):
+        """Create a copy of the metadata
+
+        Returns:
+            Metadata: a copy of the metadata
+        """
+        return deepcopy(self)
+
     def to_dict(self):
         """Convert metadata to a dict
 
@@ -178,7 +186,14 @@ class Metadata(helpers.ControlledDict):
             if descriptor is None:
                 return {}
             if isinstance(descriptor, dict):
-                return deepcopy(descriptor) if self.metadata_duplicate else descriptor
+                if not self.metadata_duplicate:
+                    return descriptor
+                try:
+                    return deepcopy(descriptor)
+                except Exception:
+                    note = "descriptor is not serializable"
+                    errors = import_module("frictionless.errors")
+                    raise exceptions.FrictionlessException(errors.Error(note=note))
             if isinstance(descriptor, str):
                 if helpers.is_remote_path(descriptor):
                     response = requests.get(descriptor)

--- a/frictionless/package.py
+++ b/frictionless/package.py
@@ -316,6 +316,14 @@ class Package(Metadata):
             ),
         )
 
+    def to_copy(self):
+        """Create a copy of the package"""
+        resources = []
+        for resource in self.resources:
+            resources.append(resource.to_copy())
+        descriptor = {key: value for key, value in self.items() if key != "resources"}
+        return Package(descriptor, resources=resources)
+
     def to_storage(self, storage, *, force=False):
         """Export package to storage
 
@@ -323,7 +331,7 @@ class Package(Metadata):
             storage (Storage): storage instance
             force (bool): overwrite existent
         """
-        storage.write_package(self, force=force)
+        storage.write_package(self.to_copy(), force=force)
         return storage
 
     def to_sql(self, *, engine, prefix="", namespace=None, force=False):

--- a/frictionless/parser.py
+++ b/frictionless/parser.py
@@ -18,6 +18,7 @@ class Parser:
 
     newline = None
     loading = True
+    # TODO: do we need it globally or it's enough to have for every plugin internally?
     native_types = []
 
     def __init__(self, resource):

--- a/frictionless/parsers/csv.py
+++ b/frictionless/parsers/csv.py
@@ -61,8 +61,7 @@ class CsvParser(Parser):
                 schema = row.schema
                 if row.row_number == 1:
                     writer.writerow(schema.field_names)
-                # NOTE: move this logic to Row?
-                cells = list(row.values())
+                cells = row.to_list()
                 cells, notes = schema.write_data(cells, native_types=self.native_types)
                 writer.writerow(cells)
         helpers.move_file(file.name, self.resource.source)

--- a/frictionless/parsers/inline.py
+++ b/frictionless/parsers/inline.py
@@ -5,6 +5,7 @@ from .. import exceptions
 from .. import errors
 
 
+# TODO: add support for a stream front matter? (resource)
 class InlineParser(Parser):
     """Inline parser implementation.
 

--- a/frictionless/parsers/inline.py
+++ b/frictionless/parsers/inline.py
@@ -76,8 +76,9 @@ class InlineParser(Parser):
 
     def write(self, row_stream):
         dialect = self.resource.dialect
+        self.resource.data = []
         for row in row_stream:
             item = row.to_dict() if dialect.keyed else list(row.values())
             if not dialect.keyed and row.row_number == 1:
-                self.resource.source.append(row.schema.field_names)
-            self.resource.source.append(item)
+                self.resource.data.append(row.schema.field_names)
+            self.resource.data.append(item)

--- a/frictionless/plugins/bigquery.py
+++ b/frictionless/plugins/bigquery.py
@@ -33,6 +33,10 @@ class BigqueryPlugin(Plugin):
             return BigqueryStorage(**options)
 
 
+# TODO: implement Dialect
+# TODO: implement Parser
+
+
 # Storage
 
 

--- a/frictionless/plugins/bigquery.py
+++ b/frictionless/plugins/bigquery.py
@@ -192,19 +192,18 @@ class BigqueryStorage(Storage):
     def write_package(self, package, *, force=False):
         existent_names = list(self)
 
-        # Copy/infer package
-        package = Package(package)
-        package.infer()
-
-        # Iterate resources
+        # Check existence
         for resource in package.resources:
-
-            # Check existence
             if resource.name in existent_names:
                 if not force:
                     note = f'Resource "{resource.name}" already exists'
                     raise exceptions.FrictionlessException(errors.StorageError(note=note))
                 self.delete_resource(resource.name)
+
+        # Write resource
+        for resource in package.resources:
+            if not resource.schema:
+                resource.infer(only_sample=True)
 
             # Write metadata
             bq_name = self.__write_convert_name(resource.name)

--- a/frictionless/plugins/bigquery.py
+++ b/frictionless/plugins/bigquery.py
@@ -192,9 +192,6 @@ class BigqueryStorage(Storage):
     def write_package(self, package, *, force=False):
         existent_names = list(self)
 
-        # Infer package
-        package.infer(only_sample=True)
-
         # Check existence
         for resource in package.resources:
             if resource.name in existent_names:
@@ -205,6 +202,8 @@ class BigqueryStorage(Storage):
 
         # Write resource
         for resource in package.resources:
+            if not resource.schema:
+                resource.infer(only_sample=True)
 
             # Write metadata
             bq_name = self.__write_convert_name(resource.name)

--- a/frictionless/plugins/bigquery.py
+++ b/frictionless/plugins/bigquery.py
@@ -192,6 +192,9 @@ class BigqueryStorage(Storage):
     def write_package(self, package, *, force=False):
         existent_names = list(self)
 
+        # Infer package
+        package.infer(only_sample=True)
+
         # Check existence
         for resource in package.resources:
             if resource.name in existent_names:
@@ -202,8 +205,6 @@ class BigqueryStorage(Storage):
 
         # Write resource
         for resource in package.resources:
-            if not resource.schema:
-                resource.infer(only_sample=True)
 
             # Write metadata
             bq_name = self.__write_convert_name(resource.name)

--- a/frictionless/plugins/ckan.py
+++ b/frictionless/plugins/ckan.py
@@ -29,6 +29,10 @@ class CkanPlugin(Plugin):
         pass
 
 
+# TODO: implement Dialect
+# TODO: implement Parser
+
+
 # Storage
 
 

--- a/frictionless/plugins/elastic.py
+++ b/frictionless/plugins/elastic.py
@@ -30,6 +30,10 @@ class ElasticPlugin(Plugin):
         pass
 
 
+# TODO: implement Dialect
+# TODO: implement Parser
+
+
 # Storage
 
 

--- a/frictionless/plugins/pandas.py
+++ b/frictionless/plugins/pandas.py
@@ -165,10 +165,6 @@ class PandasStorage(Storage):
     def write_package(self, package, *, force=False):
         existent_names = list(self)
 
-        # Copy/infer package
-        package = Package(package)
-        package.infer()
-
         # Check existent
         for resource in package.resources:
             if resource.name in existent_names:
@@ -179,6 +175,8 @@ class PandasStorage(Storage):
 
         # Write resources
         for resource in package.resources:
+            if not resource.schema:
+                resource.infer(only_sample=True)
             self.__dataframes[resource.name] = self.__write_convert_resource(resource)
 
     def __write_convert_resource(self, resource):

--- a/frictionless/plugins/pandas.py
+++ b/frictionless/plugins/pandas.py
@@ -2,10 +2,12 @@ import isodate
 import datetime
 import collections
 from functools import partial
+from ..dialects import Dialect
 from ..resource import Resource
 from ..package import Package
-from ..plugin import Plugin
 from ..storage import Storage
+from ..plugin import Plugin
+from ..parser import Parser
 from ..schema import Schema
 from ..field import Field
 from .. import exceptions
@@ -25,9 +27,72 @@ class PandasPlugin(Plugin):
 
     """
 
+    def create_dialect(self, resource, *, descriptor):
+        pd = helpers.import_from_plugin("pandas", plugin="pandas")
+        if isinstance(resource.source, pd.DataFrame):
+            return PandasDialect(descriptor)
+
+    def create_parser(self, resource):
+        pd = helpers.import_from_plugin("pandas", plugin="pandas")
+        if isinstance(resource.source, pd.DataFrame):
+            return PandasParser(resource)
+
     def create_storage(self, name, **options):
         if name == "pandas":
             return PandasStorage(**options)
+
+
+# Dialect
+
+
+class PandasDialect(Dialect):
+    """Tsv dialect representation
+
+    API      | Usage
+    -------- | --------
+    Public   | `from frictionless.plugins.pandas import PandasDialect`
+
+    Parameters:
+        descriptor? (str|dict): descriptor
+
+    Raises:
+        FrictionlessException: raise any error that occurs during the process
+
+    """
+
+    pass
+
+
+# Parser
+
+
+class PandasParser(Parser):
+    """Pandas parser implementation.
+
+    API      | Usage
+    -------- | --------
+    Public   | `from frictionless.plugins.pandas import PandasParser`
+
+    """
+
+    loading = False
+
+    # Read
+
+    def read_data_stream_create(self):
+        storage = PandasStorage(dataframes={self.resource.name: self.resource.data})
+        resource = storage.read_resource(self.resource.name)
+        self.resource.schema = resource.schema
+        yield resource.schema.field_names
+        yield from resource.read_data_stream()
+
+    # Write
+
+    def write(self, row_stream):
+        schema = self.resource.schema
+        storage = PandasStorage()
+        resource = Resource(name=self.resource.name, data=row_stream, schema=schema)
+        storage.write_resource(resource)
 
 
 # Storage

--- a/frictionless/plugins/pandas.py
+++ b/frictionless/plugins/pandas.py
@@ -165,6 +165,9 @@ class PandasStorage(Storage):
     def write_package(self, package, *, force=False):
         existent_names = list(self)
 
+        # Infer package
+        package.infer(only_sample=True)
+
         # Check existent
         for resource in package.resources:
             if resource.name in existent_names:
@@ -175,8 +178,6 @@ class PandasStorage(Storage):
 
         # Write resources
         for resource in package.resources:
-            if not resource.schema:
-                resource.infer(only_sample=True)
             self.__dataframes[resource.name] = self.__write_convert_resource(resource)
 
     def __write_convert_resource(self, resource):

--- a/frictionless/plugins/pandas.py
+++ b/frictionless/plugins/pandas.py
@@ -165,9 +165,6 @@ class PandasStorage(Storage):
     def write_package(self, package, *, force=False):
         existent_names = list(self)
 
-        # Infer package
-        package.infer(only_sample=True)
-
         # Check existent
         for resource in package.resources:
             if resource.name in existent_names:
@@ -178,6 +175,8 @@ class PandasStorage(Storage):
 
         # Write resources
         for resource in package.resources:
+            if not resource.schema:
+                resource.infer(only_sample=True)
             self.__dataframes[resource.name] = self.__write_convert_resource(resource)
 
     def __write_convert_resource(self, resource):

--- a/frictionless/plugins/pandas.py
+++ b/frictionless/plugins/pandas.py
@@ -29,12 +29,12 @@ class PandasPlugin(Plugin):
 
     def create_dialect(self, resource, *, descriptor):
         pd = helpers.import_from_plugin("pandas", plugin="pandas")
-        if isinstance(resource.source, pd.DataFrame):
+        if resource.format == "pandas" or isinstance(resource.source, pd.DataFrame):
             return PandasDialect(descriptor)
 
     def create_parser(self, resource):
         pd = helpers.import_from_plugin("pandas", plugin="pandas")
-        if isinstance(resource.source, pd.DataFrame):
+        if resource.format == "pandas" or isinstance(resource.source, pd.DataFrame):
             return PandasParser(resource)
 
     def create_storage(self, name, **options):
@@ -93,6 +93,7 @@ class PandasParser(Parser):
         storage = PandasStorage()
         resource = Resource(name=self.resource.name, data=row_stream, schema=schema)
         storage.write_resource(resource)
+        return storage.dataframe
 
 
 # Storage

--- a/frictionless/plugins/pandas.py
+++ b/frictionless/plugins/pandas.py
@@ -93,7 +93,7 @@ class PandasParser(Parser):
         storage = PandasStorage()
         resource = Resource(name=self.resource.name, data=row_stream, schema=schema)
         storage.write_resource(resource)
-        return storage.dataframe
+        self.resource.data = storage.dataframe
 
 
 # Storage

--- a/frictionless/plugins/spss.py
+++ b/frictionless/plugins/spss.py
@@ -165,14 +165,11 @@ class SpssStorage(Storage):
         return self.write_package(package, force=force)
 
     def write_package(self, package, *, force=False):
-
-        # Copy/infer package
-        package = Package(package)
-        package.infer()
+        existent_names = list(self)
 
         # Check existence
         for resource in package.resources:
-            if resource.name in self:
+            if resource.name in existent_names:
                 if not force:
                     note = f'Resource "{resource.name}" already exists'
                     raise exceptions.FrictionlessException(errors.StorageError(note=note))
@@ -180,6 +177,8 @@ class SpssStorage(Storage):
 
         # Save resources
         for resource in package.resources:
+            if not resource.schema:
+                resource.infer(only_sample=True)
             self.__write_row_stream(resource)
 
     def __write_convert_name(self, name):

--- a/frictionless/plugins/spss.py
+++ b/frictionless/plugins/spss.py
@@ -167,6 +167,9 @@ class SpssStorage(Storage):
     def write_package(self, package, *, force=False):
         existent_names = list(self)
 
+        # Infer package
+        package.infer(only_sample=True)
+
         # Check existence
         for resource in package.resources:
             if resource.name in existent_names:
@@ -177,8 +180,6 @@ class SpssStorage(Storage):
 
         # Save resources
         for resource in package.resources:
-            if not resource.schema:
-                resource.infer(only_sample=True)
             self.__write_row_stream(resource)
 
     def __write_convert_name(self, name):

--- a/frictionless/plugins/spss.py
+++ b/frictionless/plugins/spss.py
@@ -167,9 +167,6 @@ class SpssStorage(Storage):
     def write_package(self, package, *, force=False):
         existent_names = list(self)
 
-        # Infer package
-        package.infer(only_sample=True)
-
         # Check existence
         for resource in package.resources:
             if resource.name in existent_names:
@@ -180,6 +177,8 @@ class SpssStorage(Storage):
 
         # Save resources
         for resource in package.resources:
+            if not resource.schema:
+                resource.infer(only_sample=True)
             self.__write_row_stream(resource)
 
     def __write_convert_name(self, name):

--- a/frictionless/plugins/spss.py
+++ b/frictionless/plugins/spss.py
@@ -31,6 +31,10 @@ class SpssPlugin(Plugin):
             return SpssStorage(**options)
 
 
+# TODO: implement Dialect
+# TODO: implement Parser
+
+
 # Storage
 
 

--- a/frictionless/plugins/sql.py
+++ b/frictionless/plugins/sql.py
@@ -120,8 +120,8 @@ class SqlParser(Parser):
 
     def read_data_stream_create(self):
         sa = helpers.import_from_plugin("sqlalchemy", plugin="sql")
-        dialect = self.resource.dialect
         engine = sa.create_engine(self.resource.source)
+        dialect = self.resource.dialect
         storage = SqlStorage(engine=engine)
         resource = storage.read_resource(dialect.table, order_by=dialect.order_by)
         self.resource.schema = resource.schema

--- a/frictionless/plugins/sql.py
+++ b/frictionless/plugins/sql.py
@@ -326,6 +326,7 @@ class SqlStorage(Storage):
             self.delete_package(delete_names)
             for resource in package.resources:
                 if not resource.schema:
+                    # TODO: rebase on to_copy/fork/infer?
                     resource.infer(only_sample=True)
                 sql_table = self.__write_convert_schema(resource)
                 sql_tables.append(sql_table)

--- a/frictionless/plugins/sql.py
+++ b/frictionless/plugins/sql.py
@@ -326,7 +326,6 @@ class SqlStorage(Storage):
             self.delete_package(delete_names)
             for resource in package.resources:
                 if not resource.schema:
-                    # TODO: rebase on to_copy/fork/infer?
                     resource.infer(only_sample=True)
                 sql_table = self.__write_convert_schema(resource)
                 sql_tables.append(sql_table)

--- a/frictionless/plugins/sql.py
+++ b/frictionless/plugins/sql.py
@@ -115,9 +115,6 @@ class SqlParser(Parser):
     """
 
     loading = False
-    native_types = [
-        "string",
-    ]
 
     # Read
 

--- a/frictionless/resource.py
+++ b/frictionless/resource.py
@@ -591,11 +591,11 @@ class Resource(Metadata):
 
     @staticmethod
     def from_source(source, **options):
-        if source in [None, (), []]:
+        if source is None:
             return Resource(data=[], **options)
         elif isinstance(source, str):
             return Resource(path=source, **options)
-        elif isinstance(source, list) and isinstance(source[0], str):
+        elif isinstance(source, list) and source and isinstance(source[0], str):
             return Resource(path=source, **options)
         return Resource(data=source, **options)
 

--- a/frictionless/resource.py
+++ b/frictionless/resource.py
@@ -680,7 +680,7 @@ class Resource(Metadata):
             storage (Storage): storage instance
             force (bool): overwrite existent
         """
-        storage.write_resource(self, force=force)
+        storage.write_resource(self.to_copy(), force=force)
         return storage
 
     def to_sql(self, *, engine, prefix="", namespace=None, force=False):
@@ -739,6 +739,14 @@ class Resource(Metadata):
             ),
             force=force,
         )
+
+    def to_copy(self):
+        """Create a copy of the resource"""
+        if self.data and not isinstance(self.data, list):
+            # If data is not a static list e.g. a generator we can't deepcopy it
+            descriptor = {key: value for key, value in self.items() if key != "data"}
+            return Resource(descriptor, data=self.data)
+        return Resource(self)
 
     def to_dict(self, expand=False):
         """Convert resource to dict

--- a/frictionless/table.py
+++ b/frictionless/table.py
@@ -793,7 +793,7 @@ class Table:
     # TODO: allow None target and return result for inline/pandas/etc?
     def write(
         self,
-        target,
+        target=None,
         *,
         scheme=None,
         format=None,
@@ -829,7 +829,7 @@ class Table:
         # Write file
         row_stream = self.__write_row_stream_create()
         parser = system.create_parser(resource)
-        parser.write(row_stream)
+        return parser.write(row_stream)
 
     def __write_row_stream_create(self):
         self.__read_data_stream_raise_closed()

--- a/frictionless/table.py
+++ b/frictionless/table.py
@@ -569,6 +569,7 @@ class Table:
             for field in schema.fields:
                 field.update((fields.get(field.get("name"), {})))
 
+        # Validate schema
         if len(schema.field_names) != len(set(schema.field_names)):
             note = "Schemas with duplicate field names are not supported"
             raise exceptions.FrictionlessException(errors.SchemaError(note=note))
@@ -821,6 +822,7 @@ class Table:
             compression_path=compression_path,
             control=control,
             dialect=dialect,
+            schema=self.schema,
             trusted=True,
         )
 

--- a/frictionless/table.py
+++ b/frictionless/table.py
@@ -790,7 +790,7 @@ class Table:
     # Write
 
     # NOTE: implement proper usage of loaders (e.g. write to s3)
-    # NOTE: allow None target and return result for inline/pandas/etc?
+    # TODO: allow None target and return result for inline/pandas/etc?
     def write(
         self,
         target,

--- a/frictionless/table.py
+++ b/frictionless/table.py
@@ -829,7 +829,8 @@ class Table:
         # Write file
         row_stream = self.__write_row_stream_create()
         parser = system.create_parser(resource)
-        return parser.write(row_stream)
+        parser.write(row_stream)
+        return resource.source
 
     def __write_row_stream_create(self):
         self.__read_data_stream_raise_closed()

--- a/tests/parsers/test_inline.py
+++ b/tests/parsers/test_inline.py
@@ -1,4 +1,3 @@
-import pytest
 from collections import OrderedDict
 from frictionless import Table, dialects
 
@@ -73,27 +72,21 @@ def test_table_inline_from_ordered_dict():
 # Write
 
 
-@pytest.mark.skip
 def test_table_inline_write(tmpdir):
     source = "data/table.csv"
-    target = []
     with Table(source) as table:
-        table.write(target)
-    assert target == [
-        ["id", "name"],
-        [1, "english"],
-        [2, "中国人"],
-    ]
+        table.write(format="inline") == [
+            ["id", "name"],
+            [1, "english"],
+            [2, "中国人"],
+        ]
 
 
-@pytest.mark.skip
 def test_table_inline_write_keyed(tmpdir):
     source = "data/table.csv"
-    target = []
     dialect = dialects.InlineDialect(keyed=True)
     with Table(source) as table:
-        table.write(target, dialect=dialect)
-    assert target == [
-        {"id": 1, "name": "english"},
-        {"id": 2, "name": "中国人"},
-    ]
+        table.write(format="inline", dialect=dialect) == [
+            {"id": 1, "name": "english"},
+            {"id": 2, "name": "中国人"},
+        ]

--- a/tests/plugins/test_gsheet.py
+++ b/tests/plugins/test_gsheet.py
@@ -2,7 +2,7 @@ import pytest
 from frictionless import Table, exceptions
 
 
-# Loader
+# Parser
 
 
 @pytest.mark.ci

--- a/tests/plugins/test_html.py
+++ b/tests/plugins/test_html.py
@@ -3,7 +3,7 @@ from frictionless import Table
 from frictionless.plugins.html import HtmlDialect
 
 
-# Parser (read)
+# Parser
 
 
 @pytest.mark.parametrize(
@@ -21,9 +21,6 @@ def test_table_html(source, selector):
         assert table.format == "html"
         assert table.header == ["id", "name"]
         assert table.read_data() == [["1", "english"], ["2", "中国人"]]
-
-
-# Parser (write)
 
 
 def test_table_html_write(tmpdir):

--- a/tests/plugins/test_ods.py
+++ b/tests/plugins/test_ods.py
@@ -6,7 +6,7 @@ from frictionless.plugins.ods import OdsDialect
 BASE_URL = "https://raw.githubusercontent.com/okfn/tabulator-py/master/%s"
 
 
-# Parser (read)
+# Parser
 
 
 def test_table_ods():
@@ -75,9 +75,6 @@ def test_table_ods_with_ints_floats_dates():
             [1997, 5.6, datetime(2009, 9, 20).date(), datetime(2009, 9, 20, 15, 30, 0)],
             [1969, 11.7, datetime(2012, 8, 23).date(), datetime(2012, 8, 23, 20, 40, 59)],
         ]
-
-
-# Parser (write)
 
 
 def test_table_write_ods(tmpdir):

--- a/tests/plugins/test_pandas.py
+++ b/tests/plugins/test_pandas.py
@@ -1,8 +1,23 @@
 import pytest
 import isodate
 import datetime
-from frictionless import Package, Resource, exceptions
+import pandas as pd
+from frictionless import Table, Package, Resource, exceptions
 from frictionless.plugins.pandas import PandasStorage
+
+
+# Parser (read)
+
+
+def test_table_pandas():
+    dataframe = pd.DataFrame(data={"id": [1, 2], "name": ["english", "中国人"]})
+    with Table(dataframe) as table:
+        assert table.header == ["id", "name"]
+        assert table.read_data() == [
+            [1, "english"],
+            [2, "中国人"],
+        ]
+
 
 # Storage
 

--- a/tests/plugins/test_pandas.py
+++ b/tests/plugins/test_pandas.py
@@ -6,7 +6,7 @@ from frictionless import Table, Package, Resource, exceptions
 from frictionless.plugins.pandas import PandasStorage
 
 
-# Parser (read)
+# Parser
 
 
 def test_table_pandas():
@@ -16,6 +16,15 @@ def test_table_pandas():
         assert table.read_data() == [
             [1, "english"],
             [2, "中国人"],
+        ]
+
+
+def test_table_pandas_write():
+    with Table("data/table.csv") as table:
+        dataframe = table.write(format="pandas")
+        assert dataframe.to_dict("records") == [
+            {"id": 1, "name": "english"},
+            {"id": 2, "name": "中国人"},
         ]
 
 

--- a/tests/plugins/test_sql.py
+++ b/tests/plugins/test_sql.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 load_dotenv(".env")
 
 
-# Parser (read)
+# Parser
 
 
 def test_table_sql(database_url):
@@ -54,9 +54,6 @@ def test_table_sql_headers_false(database_url):
     with Table(database_url, dialect=dialect, headers=False) as table:
         assert table.header == []
         assert table.read_data() == [["id", "name"], [1, "english"], [2, "中国人"]]
-
-
-# Parser (write)
 
 
 def test_table_sql_write(database_url):

--- a/tests/plugins/test_sql.py
+++ b/tests/plugins/test_sql.py
@@ -66,7 +66,7 @@ def test_table_sql_write(database_url):
         table.write(database_url, dialect=dialect)
     with Table(database_url, dialect=dialect) as table:
         assert table.header == ["id", "name"]
-        assert table.read_data() == [["1", "english"], ["2", "中国人"]]
+        assert table.read_data() == [[1, "english"], [2, "中国人"]]
 
 
 # Storage

--- a/tests/plugins/test_sql.py
+++ b/tests/plugins/test_sql.py
@@ -12,28 +12,35 @@ load_dotenv(".env")
 # Parser (read)
 
 
-def test_table_format_sql(database_url):
+def test_table_sql(database_url):
     dialect = SqlDialect(table="data")
     with Table(database_url, dialect=dialect) as table:
+        assert table.schema == {
+            "fields": [
+                {"constraints": {"required": True}, "name": "id", "type": "integer"},
+                {"name": "name", "type": "string"},
+            ],
+            "primaryKey": ["id"],
+        }
         assert table.header == ["id", "name"]
         assert table.read_data() == [[1, "english"], [2, "中国人"]]
 
 
-def test_table_format_sql_order_by(database_url):
+def test_table_sql_order_by(database_url):
     dialect = SqlDialect(table="data", order_by="id")
     with Table(database_url, dialect=dialect) as table:
         assert table.header == ["id", "name"]
         assert table.read_data() == [[1, "english"], [2, "中国人"]]
 
 
-def test_table_format_sql_order_by_desc(database_url):
+def test_table_sql_order_by_desc(database_url):
     dialect = SqlDialect(table="data", order_by="id desc")
     with Table(database_url, dialect=dialect) as table:
         assert table.header == ["id", "name"]
         assert table.read_data() == [[2, "中国人"], [1, "english"]]
 
 
-def test_table_format_sql_table_is_required_error(database_url):
+def test_table_sql_table_is_required_error(database_url):
     table = Table(database_url)
     with pytest.raises(exceptions.FrictionlessException) as excinfo:
         table.open()
@@ -42,7 +49,7 @@ def test_table_format_sql_table_is_required_error(database_url):
     assert error.note.count("'table' is a required property")
 
 
-def test_table_format_sql_headers_false(database_url):
+def test_table_sql_headers_false(database_url):
     dialect = SqlDialect(table="data")
     with Table(database_url, dialect=dialect, headers=False) as table:
         assert table.header == []
@@ -52,7 +59,7 @@ def test_table_format_sql_headers_false(database_url):
 # Parser (write)
 
 
-def test_table_write_sqlite(database_url):
+def test_table_sql_write(database_url):
     source = "data/table.csv"
     dialect = SqlDialect(table="name", order_by="id")
     with Table(source) as table:

--- a/tests/plugins/test_tsv.py
+++ b/tests/plugins/test_tsv.py
@@ -1,7 +1,7 @@
 from frictionless import Table
 
 
-# Parser (read)
+# Parser
 
 
 def test_table_format_tsv():
@@ -12,9 +12,6 @@ def test_table_format_tsv():
             ["2", "中国人"],
             ["3", None],
         ]
-
-
-# Parser (write)
 
 
 def test_table_tsv_write(tmpdir):


### PR DESCRIPTION
- fixes #396 

---

Now when you do something like the code snippet below you will get a schema from the database instead of an inferred one:

```python
from frictionless import Table

with Table('postgresql://...', dialect={'table': 'cities'}) as table:
  print(table.schema)  # inspected from the database
  print(table.read_rows())
```