### PR TITLE
add @pytest.mark.ci to two SQL tests

### DIFF
--- a/tests/plugins/test_sql.py
+++ b/tests/plugins/test_sql.py
@@ -485,6 +485,7 @@ def test_postgresql_storage_constraints_not_valid_error(database_url, field_name
         resource.to_sql(engine=engine, force=True)
 
 
+@pytest.mark.ci
 def test_postgresql_storage_views_support():
     engine = sa.create_engine(os.environ["POSTGRESQL_URL"])
     engine.execute("DROP VIEW IF EXISTS data_view")
@@ -698,6 +699,7 @@ def test_mysql_storage_constraints_not_valid_error(field_name, cell):
         resource.to_sql(engine=engine, force=True)
 
 
+@pytest.mark.ci
 def test_mysql_storage_views_support():
     engine = sa.create_engine(os.environ["MYSQL_URL"])
     engine.execute("DROP VIEW IF EXISTS data_view")


### PR DESCRIPTION
# Overview

These two tests are missing the `@pytest.mark.ci` decorator.
Because the test suite runs in a pre-commit hook this means I either have to have a local test DB set up or make every commit with `--no-verify` (somewhat negating the point of the hook)

---

Please preserve this line to notify @roll (lead of this repository)
