### PR TITLE
Fixed text path parsing

### DIFF
--- a/frictionless/location.py
+++ b/frictionless/location.py
@@ -37,6 +37,8 @@ class Location:
             detect = helpers.detect_source_scheme_and_format(new_source)
         scheme = detect[0] or config.DEFAULT_SCHEME
         format = detect[1] or config.DEFAULT_FORMAT
+        if scheme == "text" and source.endswith(f".{format}"):
+            source = source[: -(len(format) + 1)]
 
         # Set attributes
         self.__name = name

--- a/tests/loaders/test_text.py
+++ b/tests/loaders/test_text.py
@@ -9,3 +9,10 @@ def test_table_text():
     with Table(source, format="csv") as table:
         assert table.header == ["header1", "header2"]
         assert table.read_data() == [["value1", "value2"], ["value3", "value4"]]
+
+
+def test_table_text_format_in_path():
+    source = "text://header1,header2\nvalue1,value2\nvalue3,value4.csv"
+    with Table(source) as table:
+        assert table.header == ["header1", "header2"]
+        assert table.read_data() == [["value1", "value2"], ["value3", "value4"]]


### PR DESCRIPTION
# Overview

```python
def test_table_text_format_in_path():
    source = "text://header1,header2\nvalue1,value2\nvalue3,value4.csv"
    with Table(source) as table:
        assert table.header == ["header1", "header2"]
        assert table.read_data() == [["value1", "value2"], ["value3", "value4"]]
```
