### PR TITLE
Fix typos, grammar in docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We use Github as a code and issues hosting platform. To report a bug or propose 
 ## Docs Contribution
 
 We use a flexible documentation system as the docs are generated from:
-- markdown documents in the `docs` directory interpreted by the Jupiter Notebook runner
+- markdown documents in the `docs` directory interpreted by the Jupyter Notebook runner
 - python scripts in the `docs` directory generating references or copying documents from the root directory such as `README.md`, `CHANGELOG.md` etc
 
 To contribute to the documentation, please check to the corresponding `docs/name.md|py` file to understand the source of a document. If it's a markdown just edit it in-line if it's a script edit it or find a corresponding document in the root directory.

--- a/docs/describing-data.md
+++ b/docs/describing-data.md
@@ -159,7 +159,7 @@ Our resource metadata includes the schema metadata we created earlier but also i
 - information about CSV Dialect helping software understand how to read it
 - checksum information as though hash, bytes, and rows
 
-But the most important difference is that resource metadata contains the `path` property. It conceptually distinct Data Resource specification from Table Schema specification because while a Table Schema descriptor can describe a class of data files, a Data Resource descriptor describes the only one exact data file, `data/country-2.csv` in our case.
+But the most important difference is that resource metadata contains the `path` property. Presence of `path` conceptually distiguishes a Data Resource specification from a Table Schema specification. While a Table Schema descriptor can describe a class of data files, a Data Resource descriptor describes only one exact data file, `data/country-2.csv` in our case.
 
 Using programming terminology we could say that:
 - Table Schema descriptor is abstract (for a class of files)
@@ -275,13 +275,13 @@ Trying to extract the data will fail the same way:
 ! frictionless extract data/country-2.csv
 ```
 
-Basically, that's a really important idea - with not metadata many software will not be able to even read this data file, furthermore, without metadata people can not understand the purpose of this data. Let's now use the `country.resource.yaml` the file we created in the "Data Resource" section:
+Basically, that's a really important idea - without metadata many software products will not be able to even read this data file, furthermore, without metadata people can not understand the purpose of this data. Let's now use the `country.resource.yaml` file we created in the "Data Resource" section:
 
 ```python
 ! frictionless extract tmp/country.resource.yaml --basepath .
 ```
 
-As we can see, it's now fixed. The metadata we'd had saved the day. If we explore this data in Python we can discover that it also correct data types e.g. `id` is Python's integer not string. This fact will allow exporting and sharing this data without any fear.
+As we can see, it's now fixed. The metadata we had saved the day. If we explore this data in Python we can discover that it also correct data types e.g. `id` is Python's integer not string. This fact will allow exporting and sharing this data without any fear.
 
 ## Metadata Classes
 
@@ -337,7 +337,7 @@ resource = describe("data/country-1.csv")
 pprint(resource.schema)
 ```
 
-Under the hood it, for example, still treats empty string as missing values because it's the specs' default. We can make reveal implicit metadata by expanding it:
+Under the hood it, for example, still treats empty string as missing values because it's the specs' default. We can reveal implicit metadata by expanding it:
 
 ```python
 resource.schema.expand()
@@ -442,7 +442,7 @@ This option allows manually setting all the field types to a given type. It's us
 
 ### Infer Names
 
-Sometimes you don't want to use existent header row to compose field names. It's possible to provide custom names:
+Sometimes you don't want to use an existing header row to compose field names. It's possible to provide custom names:
 
 ```python
 from frictionless import describe

--- a/docs/extracting-data.md
+++ b/docs/extracting-data.md
@@ -433,7 +433,7 @@ There are a great deal of options available for different dialects that can be f
 
 ### Header
 
-It's a boolean flag wich deaults to `True` indicating whether the data has a header row or not. In the following example the header row will be treated as a data row:
+It's a boolean flag which deaults to `True` indicating whether the data has a header row or not. In the following example the header row will be treated as a data row:
 
 ```python
 from frictionless import Table, Dialect
@@ -525,7 +525,7 @@ print(extract('data/matrix.csv', query=Query(offset_fields=2)))
 
 ### Pick/Skip Rows
 
-It's alike the field counterparts but it will be compared to the first cell of a row. All the queries below do the same thing for this file but take into account that when picking we need to also pick a header row. In addition, there is special value `<blank>` that matches a row if it's competely blank:
+We can also select rows in a way similar to the Table's field counterpart. In the case of rows, the list of included/excluded elements will be compared to the first cell of a row. All the queries below do the same thing for this file but take into account that when providing the elements we need to also ensure a header row is delivered to the `extract` process. In addition, there is special value `<blank>` that matches a row if it's competely blank:
 
 ```python
 from frictionless import extract, Query
@@ -552,9 +552,9 @@ print(extract('data/matrix.csv', query=Query(offset_rows=2)))
 
 ## Header Options
 
-Header management is a responsibility of "Table Dialect" which will be described below but Table accept a special `headers` argument that plays a role of a high-level helper in setting different header options.
+Header management is a responsibility of "Table Dialect" which is introduced above but `Table` accepts a special `headers` argument that plays a role of a high-level helper in setting different header options.
 
-It accepts a `False` values indicating that there is no header row:
+It accepts a value of `False` indicating that there is no header row:
 
 ```python
 from frictionless import Table
@@ -584,7 +584,7 @@ with Table('data/capital-3.csv', headers=[1,2,3]) as table:
     pprint(table.read_rows())
 ```
 
-It accepts a pair containing a list of integers indicating a multiline header row numbers and a string indicating a joiner for a concatenate operation:
+It accepts a pair containing in the first position a list of integers indicating row numbers of a multiline header and in the second position a string indicating a joiner for a concatenate operation:
 
 ```python
 from frictionless import Table
@@ -716,7 +716,7 @@ The example above covers the case when a header is valid. For a header with tabu
 
 ## Row Object
 
-The `extract`, `resource.read_rows()`, `table.read_rows()`, and many other functions return or yeild row objects. It's an `OrderedDict` providing additional API shown below:
+The `extract`, `resource.read_rows()`, `table.read_rows()`, and many other functions return or yield row objects. It's an `OrderedDict` providing additional API shown below:
 
 ```python
 from frictionless import Table

--- a/docs/validating-data.md
+++ b/docs/validating-data.md
@@ -1,6 +1,6 @@
 # Validating Data
 
-Tabular data validation is a process of identifying tabular problems that have place in your data for further correction. Let's explore how Frictionless helps to achieve these tasks using an invalid data table example:
+Tabular data validation is a process of identifying tabular problems that occur in your data for further correction. Let's explore how Frictionless helps to achieve these tasks using an invalid data table example:
 
 ```python
 ! cat data/capital-invalid.csv
@@ -19,7 +19,7 @@ The high-level interface for validating data provided by Frictionless is a set o
 - `validate_schema`: it validates a schema's metadata
 - `validate_resource`: it validates a resource's data and metadata
 - `validate_package`: it validates a package's data and metadata
-- `validate_inquiery`: it validates a special `Inquiery` object which represents a validation task instruction
+- `validate_inquiry`: it validates a special `Inquiry` object which represents a validation task instruction
 - `validate_table`: it validates a table
 
 In command-line, there is only 1 command but there is a flag to adjust the behavior:
@@ -35,7 +35,7 @@ $ frictionless validate --source-type table
 
 ### Validating Schema
 
-The `validate_schema` function is the only function validating solely metadata. Let's create a invalid table schema:
+The `validate_schema` function is the only function validating solely metadata. Let's create an invalid table schema:
 
 ```python
 from frictionless import Schema
@@ -61,7 +61,7 @@ As it was shown in the "Describing Data" guide a resource is a container having 
 ! frictionless describe data/capital-invalid.csv --json > tmp/capital.resource.json
 ```
 
-Let's now use the command-line interface to ensure that we are getting the same result as we had withouth using a resource:
+Let's now use the command-line interface to ensure that we are getting the same result as we had without using a resource:
 
 ```python
 ! frictionless validate tmp/capital.resource.json --basepath .
@@ -103,7 +103,7 @@ As we can see, the result is pretty straight-forward and expected: we have one i
 
 ### Validating Inquiry
 
-The Inquiry gives you an ability to create arbitrary validation jobs containing a set of individual validation taks. Let's create an inquiry that includes an individual file validation and a resource validation:
+The Inquiry gives you an ability to create arbitrary validation jobs containing a set of individual validation tasks. Let's create an inquiry that includes an individual file validation and a resource validation:
 
 ```python
 from frictionless import Inquiry
@@ -115,13 +115,13 @@ inquiry = Inquiry({'tasks': [
 inquiry.to_yaml('tmp/capital.inquiry.yaml')
 ```
 
-Tasks in the Inquiry accept the same arguments written in camelCase as the corresponding `validate` functions have. As usual, let' run validation:
+Tasks in the Inquiry accept the same arguments written in camelCase as the corresponding `validate` functions have. As usual, let's run validation:
 
 ```python
 ! frictionless validate tmp/capital.inquiry.yaml
 ```
 
-At first sight, it's no clear why such a construct exists but when your validation workflow gets complex, the Inquiry can provide a lot of flexibility and power. Last but not least, the Inquiry will use multiprocessing if there are more than 1 task provided.
+At first sight, it's not clear why such a construct exists but when your validation workflow gets complex, the Inquiry can provide a lot of flexibility and power. Last but not least, the Inquiry will use multiprocessing if there are more than 1 task provided.
 
 ### Validating Table
 
@@ -143,7 +143,7 @@ The `validate_schema` and `validate_inquiry` don't accept any options in additio
 
 ### Resource/Package
 
-The Resource and Package incapsulate most of information within their descriptor so the amount of additional options is really limited:
+The Resource and Package encapsulate most of information within their descriptor so the amount of additional options is really limited:
 - `basepath`: base path for a resource/package
 - `noinfer`: a flag disabling an infer function call
 
@@ -176,7 +176,7 @@ report = validate('data/capital-invalid.csv', pick_errors=['duplicate-header'])
 pprint(report)
 ```
 
-As we can see, there are a lot of information; you can find its details description in "API Reference". Errors are groupped by tables; for some validation there are can be dozens of tables. Let's use the `report.flatten` function to simplify errors representation:
+As we can see, there are a lot of information; you can find its details description in "API Reference". Errors are grouped by tables; for some validation exercises there can be dozens of tables. Let's use the `report.flatten` function to simplify errors representation:
 
 ```python
 from frictionless import validate
@@ -185,7 +185,7 @@ report = validate('data/capital-invalid.csv', pick_errors=['duplicate-header'])
 pprint(report.flatten(['rowPosition', 'fieldPosition', 'code', 'message']))
 ```
 
-In some situation, an error can't be associated with a table; then it goes to the top-level `report.errors` property:
+In some situations, an error can't be associated with a table; then it goes to the top-level `report.errors` property:
 
 ```python
 from frictionless import validate_schema
@@ -266,7 +266,7 @@ pprint(report.flatten(['rowPosition', 'fieldPosition', 'code']))
 
 ## Memory Options
 
-Frictionless is a streaming engine; usually it's possible to validate terrabytes of data with basically O(1) memory consumption. For some validation, it's not the case because Frctionless needs to buffer some cells e.g. to checks uniqueness. Here memory management can be handy.
+Frictionless is a streaming engine; usually it's possible to validate terabytes of data with basically O(1) memory consumption. For some validation, it's not the case because Frictionless needs to buffer some cells e.g. to checks uniqueness. Here memory management can be handy.
 
 ### Limit Memory
 
@@ -284,7 +284,7 @@ print(report.flatten(["code", "note"]))
 
 ## Checks Options
 
-Ther are two check options: `checksum` and `extra_checks`. The first allows to stricten a baseline validation white the latter is used to enforce additional checks.
+There are two check options: `checksum` and `extra_checks`. The first allows to stricten a baseline validation while the latter is used to enforce additional checks.
 
 ### Checksum
 
@@ -298,7 +298,7 @@ report = validate('data/capital-invalid.csv', checksum={'hash': 'bad'}, pick_err
 print(report.flatten(["code", "note"]))
 ```
 
-The same can be show for the bytes and rows:
+The same can be shown for the bytes and rows:
 
 ```python
 from frictionless import validate
@@ -313,7 +313,7 @@ It's possible to provide a list of extra checks where individual checks are in t
 - a string: `check-name`
 - a list: `['check-name', {'option1': 'value1'}]`
 
-It's also possible to use a `Check` subclass instead of name which will be shown in the "Custom Checks" section. Let's have a loot at an example:
+It's also possible to use a `Check` subclass instead of name which will be shown in the "Custom Checks" section. Let's have a look at an example:
 
 ```python
 from frictionless import validate
@@ -326,7 +326,7 @@ See the sections below for a list of available checks.
 
 ## Baseline Check
 
-By default, Frictionless runs only the Baseline Check but includes vairous smaller checks revealing a great deal of tabular errors. There is a `report.tables[].scope` property to check what exact errors it have been checked for:
+By default, Frictionless runs only the Baseline Check but includes various smaller checks revealing a great deal of tabular errors. There is a `report.tables[].scope` property to check what exact errors it have been checked for:
 
 ```python
 from frictionless import validate
@@ -337,11 +337,11 @@ pprint(report.table.scope)
 
 ## Heuristic Checks
 
-There is a group of checks that indicate probable errors. You need to use the `extra_checks` argument of the `validate` function to active one or more of these checks.
+There is a group of checks that indicate probable errors. You need to use the `extra_checks` argument of the `validate` function to activate one or more of these checks.
 
 ### Duplicate Row
 
-This check is self-explanatory. You need to take into account that checking for duplicate rows can lean to high memory consumption on big files. Here is an example:
+This check is self-explanatory. You need to take into account that checking for duplicate rows can lead to high memory consumption on big files. Here is an example:
 
 
 ```python
@@ -400,7 +400,7 @@ pprint(report.flatten(['code', 'message']))
 
 ### Sequential Value
 
-This check gives us an opportunity to validate sequential fields like primary keys or other similiar data. It doesn't need to start from 0 or 1. We're providing a field name:
+This check gives us an opportunity to validate sequential fields like primary keys or other similar data. It doesn't need to start from 0 or 1. We're providing a field name:
 
 ```python
 from pprint import pprint
@@ -414,7 +414,7 @@ pprint(report.flatten(['code', 'message']))
 
 ### Row Constraint
 
-This checks is the most powerful one as it uses the external `simpleeval` package allowing to evalute arbitrary python expressions on data rows. Let's show on an example:
+This is the most powerful check as it uses the external `simpleeval` package allowing to evaluate arbitrary python expressions on data rows. Let's show on an example:
 
 ```python
 from pprint import pprint
@@ -434,7 +434,7 @@ pprint(report.flatten(["code", "message"]))
 
 ## Custom Checks
 
-There are many cases when built-in Frictionless' checks are not enough. It can be a business logic rule or specific quality requirement to the data. With Frictionless it's very easy to use your own custom checks. Let's see on an example:
+There are many cases when Frictionless' built-in checks are not enough. It can be a business logic rule or specific quality requirement to the data. With Frictionless it's very easy to use your own custom checks. Let's see with an example:
 
 ```python
 from pprint import pprint
@@ -454,4 +454,4 @@ report = validate(source,  scheme='text', format='csv', extra_checks=extra_check
 pprint(report.flatten(["rowPosition", "fieldPosition", "code", "note"]))
 ```
 
-Usualy, it also makes sense to create a custom error for your custom check. The Check class provides other useful methods like `validate_header` etc. Please read "API Reference" to learn it in details.
+Usually, it also makes sense to create a custom error for your custom check. The Check class provides other useful methods like `validate_header` etc. Please read "API Reference" to learn it in details.

--- a/frictionless/describe/resource.py
+++ b/frictionless/describe/resource.py
@@ -47,7 +47,7 @@ def describe_resource(
         format? (str): File source's format (csv, xls, ...).
             If not set, it'll be inferred from `source`.
 
-        encoding? (str): An algorithm to hash data.
+        hashing? (str): An algorithm to hash data.
             It defaults to 'md5'.
 
         encoding? (str): Source encoding.


### PR DESCRIPTION
# Overview

Referencing #597, this PR fixes some typos and other issues with the legibility of the docs.
It is not all-encompassing, but I went through the major introductory pages and made surface-level changes.

---

This commit adds fixes to the docs for typos and grammatical mistakes.
Most changes affect only one line, but many also span across sentences
and may have the potential to change the meaning of the documentation.
Changes to the meaning/interpretation of the docs is not intentional.

This also fixes the label of a duplicated kwarg in `describe_resource`.

encoding --> hashing

---

Please preserve this line to notify @roll (lead of this repository)
