### PR TITLE
Adds link to repository

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -54,7 +54,7 @@ $ frictionless transform --help
 
 ## Example
 
-> All the examples use the data folder from this repository
+> All the examples use the data folder from [this](https://github.com/frictionlessdata/frictionless-py/) repository
 
 We will take a very dirty data file:
 


### PR DESCRIPTION
For people accessing this tutorial via frictionlessdata.github.io, it might not immediately be clear, which repository is meant by 'this'.

I assume, that people working with frictionless have sufficient knowledge to perform a checkout of this repository to access the data.

Note: working from the checked out repository directory will operate on current master, not the version installed via pip install.
This could break some tutorial examples, as is currently the case for 4.x-master and 3.48.0 stable release.

---

Please preserve this line to notify @roll (lead of this repository)
