### PR TITLE
Adding missing 'c's

### DIFF
--- a/docs/references/references-overview.md
+++ b/docs/references/references-overview.md
@@ -8,23 +8,23 @@ In this section you can find detailed references for:
 
 List of options for schemes and formats:
 
-- [Schemes Referene](schemes-reference.md)
+- [Schemes Reference](schemes-reference.md)
 - [Formats Reference](formats-reference.md)
 
 ## Plugins
 
 List of Frictionless Framework plugins and their status:
 
-- [Plugins Referene](plugins-reference.md)
+- [Plugins Reference](plugins-reference.md)
 
 ## Errors
 
 List of Frictionless Framework errors
 
-- [Errors Referene](errors-reference.md)
+- [Errors Reference](errors-reference.md)
 
 ## API
 
 Full API reference
 
-- [API Referene](api-reference.md)
+- [API Reference](api-reference.md)


### PR DESCRIPTION
For some reason a bunch of 'c's had dropped out of the instances of the word 'Reference' here. I've added them back in.

# Overview

Please replace this line with full information about your pull request. Make sure that tests pass before publishing it

---

Please preserve this line to notify @roll (lead of this repository)
