### PR TITLE
adds an example, an explanation, a link, fixes a typo, etc.

### DIFF
--- a/docs/guides/extracting-data.md
+++ b/docs/guides/extracting-data.md
@@ -111,7 +111,7 @@ from frictionless import Resource
 
 resource = Resource('data/capital-3.csv')
 resource.infer()
-resource.schema.missing_values.append('3')
+resource.schema.missing_values.append('3') # will interpret 3 as a missing value
 resource.to_yaml('tmp/capital.resource.yaml')
 ```
 
@@ -134,7 +134,7 @@ None  Paris
 ====  ======
 ```
 
-So what's happened? We set the textual representation of the number "3" to be a missing value. It was done only for presentational purposes because it's definitely not a missing value. On the other hand, it demonstrated how metadata can be used.
+So what's happened? We set the textual representation of the number "3" to be a missing value. It was done only for illustrational purposes because it's definitely not a missing value. On the other hand, it demonstrated how metadata can be used.
 
 ## Extracting Package
 
@@ -200,7 +200,7 @@ for path, rows in data.items():
 
 ## Resource Class
 
-The Resource class is also a metadata class which provides various read and stream functions. The `extract` functions always read rows into memory; Resource can do the same but it also gives a choice regarding output data. It can be `rows`, `data`, `text`, or `bytes`. Let's try reading all of them:
+The Resource class is also a metadata class which provides various read and stream functions. The `extract` functions always reads rows into memory; Resource can do the same but it also gives a choice regarding output data. It can be `rows`, `data`, `text`, or `bytes`. Let's try reading all of them:
 
 ```python title="Python"
 from frictionless import Resource
@@ -267,7 +267,7 @@ The Package class is a metadata class which provides an ability to read its cont
 frictionless describe data/*-3.csv --json > tmp/country.package.json
 ```
 
-Now, we can open the created descriptor and read the package's resources:
+We can also create a descriptor with the Package class in Python and read the package's resources:
 
 ```python title="Python"
 from frictionless import Package
@@ -320,7 +320,7 @@ with Resource('data/capital-3.csv') as resource:
     As List: ['id', 'name']
 
 
-The example above covers the case when a header is valid. For a header with tabular errors this information can be much more useful revealing discrepancies, duplicates or missing cells information. Please read "API Reference" for more details.
+The example above covers the case when a header is valid. For a header with tabular errors this information can be much more useful revealing discrepancies, duplicates or missing cells information. Please read "[API Reference](/docs/references/api-reference/)" for more details.
 
 ## Row Class
 
@@ -337,6 +337,7 @@ with Resource('data/capital-3.csv', detector=detector) as resource:
     print(f'Fields: {row.fields}')
     print(f'Field Names: {row.field_names}')
     print(f'Field Positions: {row.field_positions}')
+    print(f'Value of field "name": {row["name"]}') # accessed as a dict
     print(f'Row Position: {row.row_position}') # physical line number starting from 1
     print(f'Row Number: {row.row_number}') # counted row number starting from 1
     print(f'Blank Cells: {row.blank_cells}')
@@ -349,10 +350,11 @@ with Resource('data/capital-3.csv', detector=detector) as resource:
 ```
 ```
 Row: Row([('id', None), ('name', 'London')])
-Cells: ['1', 'londong']
+Cells: ['1', 'London']
 Fields: [{'name': 'id', 'type': 'integer'}, {'name': 'name', 'type': 'string'}]
 Field Names: ['id', 'name']
 Field Positions: [1, 2]
+Value of field "name": London
 Row Position: 2
 Row Number: 1
 Blank Cells: {'id': '1'}


### PR DESCRIPTION
# Overview

This is part of a review of documentation for the user feedback session. Overall I think it is excelent and I was able to follow it with ease.

A few comments on the content of the document and/or proposed changes follow.

## Style related questions

I've noticed that the documentation is not enforcing a 78 columns line width, so I have not changed any of the long lines.

Shouldn't references to classes be enclosed in code, e.g. `Resource`? I have not changed the current style of not marking it as code.

## Clarity

I was a little confused about the explanation on why the documentation says the code in [the Extracting Resource section](https://framework.frictionlessdata.io/docs/guides/extracting-data/#extracting-resource) does not make sense, but I have not changed it. It's the excerpt below:

> In many cases, the code above doesn't really make sense as we can just provide a path to the high-level extract function instead of a descriptor to the extract_resource function but the power of the descriptor is that it can contain different metadata and be stored on the disc. 

In [the Package Class section](https://framework.frictionlessdata.io/docs/guides/extracting-data/#package-class), the Python code doesn't really require us to create the data package json beforehand, so I've changed the wording in there.

## Code instructions

For the code instructions, it's not clear if the user should reuse the same Python terminal as the previous code examples, or create a new one. Some classes are repeatedly imported again, but not `pprint`, which is imported only in the first code example. I think we should choose one or the other (either a reused terminal or a new terminal) and be consistent with that choice.

---

Please preserve this line to notify @roll (lead of this repository)
