### PR TITLE
Consistently use period after last sentence in blockqoutes

### DIFF
--- a/docs/guides/basic-examples.md
+++ b/docs/guides/basic-examples.md
@@ -6,7 +6,7 @@ title: Basic Examples
 
 Let's start with an example dataset. We will look at a few raw data files that have recently been collected by an anthropologist. The anthropologist wants to publish this data in an open repository so her colleagues can also use this data. Before publishing the data, she wants to add metadata and check the data for errors. We are here to help, so let’s start by exploring the data. We see that the quality of data is far from perfect. In fact, the first row contains comments from the anthropologist! To be able to use this data, we need to clean it up a bit.
 
-> Download [`countries.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/countries.csv) into the `data` folder to reproduce the examples
+> Download [`countries.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/countries.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/countries.csv

--- a/docs/guides/describing-data.md
+++ b/docs/guides/describing-data.md
@@ -78,7 +78,7 @@ Table Schema is a specification for providing a "schema" (similar to a database 
 
 We're going to use this file for the examples in this section. For this guide, we only use CSV files because of their demonstrativeness, but in-general Frictionless can handle data in Excel, JSON, SQL, and many other formats:
 
-> Download [`country-1.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/country-1.csv) into the `data` folder to reproduce the examples
+> Download [`country-1.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/country-1.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/country-1.csv
@@ -186,7 +186,7 @@ A range of other properties can be declared to provide a richer set of metadata.
 
 For this section, we will use a file that is slightly more complex to handle. For some reason, cells are separated by the ";" char and there is a comment on the top:
 
-> Download [`country-2.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/country-2.csv) into the `data` folder to reproduce the examples
+> Download [`country-2.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/country-2.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/country-2.csv
@@ -322,7 +322,7 @@ The data included in the package may be provided as:
 
 For this section, we will use the following files:
 
-> Download [`country-3.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/country-3.csv) into the `data` folder to reproduce the examples
+> Download [`country-3.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/country-3.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/country-3.csv
@@ -336,7 +336,7 @@ id,capital_id,name,population
 5,4,Spain,47
 ```
 
-> Download [`capital-3.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/capital-3.csv) into the `data` folder to reproduce the examples
+> Download [`capital-3.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/capital-3.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/capital-3.csv
@@ -572,7 +572,7 @@ pprint(resource)
 
 Frictionless always tries to be as explicit as possible. We didn't provide any metadata except for `path` so we got the expected result. But now, we'd like to `infer` additional metadata:
 
-> Note that we use the `stats` argument for the `resource.infer` function. We can ask for stats using CLI with `frictionless describe data/table.csv --stats`
+> Note that we use the `stats` argument for the `resource.infer` function. We can ask for stats using CLI with `frictionless describe data/table.csv --stats`.
 
 
 ```python title="Python"

--- a/docs/guides/extension/format-guide.md
+++ b/docs/guides/extension/format-guide.md
@@ -10,7 +10,7 @@ The Parser is responsible for parsing data from/to different data sources as tho
 
 ## Parser Example
 
-> This parser has quite a naive experimental implementation
+> This parser has quite a naive experimental implementation.
 
 ```python title="Python"
 class HtmlParser(Parser):

--- a/docs/guides/extension/step-guide.md
+++ b/docs/guides/extension/step-guide.md
@@ -6,7 +6,7 @@ The Step concept is a part of the Transform API. You can create a custom Step to
 
 ## Step Example
 
-> This step uses PETL under the hood
+> This step uses PETL under the hood.
 
 ```python title="Python"
 class cell_set(Step):

--- a/docs/guides/extracting-data.md
+++ b/docs/guides/extracting-data.md
@@ -4,7 +4,7 @@ title: Extracting Data
 
 Extracting data means reading tabular data from a source. We can use various customizations for this process such as providing a file format, table schema, limiting fields or rows amount, and much more. Let's see this with some real files:
 
-> Download [`country-3.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/country-3.csv) into the `data` folder to reproduce the examples
+> Download [`country-3.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/country-3.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/country-3.csv
@@ -17,7 +17,7 @@ id,capital_id,name,population
 4,5,Italy,60
 5,4,Spain,47
 ```
-> Download [`capital-3.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/capital-3.csv) into the `data` folder to reproduce the examples
+> Download [`capital-3.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/capital-3.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/capital-3.csv

--- a/docs/guides/introduction.md
+++ b/docs/guides/introduction.md
@@ -8,7 +8,7 @@ title: Introduction
 [![Codebase](https://img.shields.io/badge/github-master-brightgreen)](https://github.com/frictionlessdata/frictionless-py)
 [![Support](https://img.shields.io/badge/chat-discord-brightgreen)](https://discord.com/channels/695635777199145130/695635777199145133)
 
-> Frictionless@4 is now live! Please read the [migration guide](https://framework.frictionlessdata.io/docs/development/migration)
+> Frictionless@4 is now live! Please read the [migration guide](https://framework.frictionlessdata.io/docs/development/migration).
 
 Frictionless is a framework to describe, extract, validate, and transform tabular data (DEVT Framework). It supports a great deal of data schemes and formats, as well as provides popular platforms integrations. The framework is powered by the lightweight yet comprehensive [Frictionless Data Specifications](https://specs.frictionlessdata.io/).
 
@@ -52,7 +52,7 @@ Frictionless is a complete data solution providing rich functionality. It's hard
 
 Frictionless can be run on CLI, in Python, and even as an API server. We will show the simplest example to get started with the framework:
 
-> Download [`invalid.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/invalid.csv) into the `data` folder to reproduce the examples
+> Download [`invalid.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/invalid.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 pip install frictionless
@@ -77,7 +77,7 @@ frictionless validate data/invalid.csv
 
 ## User Stories
 
-> TODO: Add visual diagrams here
+> TODO: Add visual diagrams here.
 
 Frictionless is a DEVT-framework (describe-extract-validate-transform). In contrast to ETL-frameworks (extract-transform-load), Frictionless does not have a linear flow. For example, let’s look at some user stories:
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -6,7 +6,7 @@ Let's get started with Frictionless! We will learn how to install and use the fr
 
 ## Installation
 
-> The framework requires Python3.6+. Versioning follows the [SemVer Standard](https://semver.org/)
+> The framework requires Python3.6+. Versioning follows the [SemVer Standard](https://semver.org/).
 
 ```bash title="CLI"
 pip install frictionless
@@ -65,11 +65,11 @@ frictionless transform --help
 
 ## Example
 
-> For more examples, use the [Basic Examples](basic-examples.md)
+> For more examples, use the [Basic Examples](basic-examples.md).
 
 We will take a very messy data file:
 
-> Download [`invalid.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/invalid.csv) into the `data` folder to reproduce the examples
+> Download [`invalid.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/invalid.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/invalid.csv

--- a/docs/guides/transform-guide.md
+++ b/docs/guides/transform-guide.md
@@ -2,7 +2,7 @@
 title: Transform Guide
 ---
 
-> This guide assumes basic familiarity with the Frictionless Framework. To learn more, please read the [Introduction](https://framework.frictionlessdata.io/docs/guides/introduction) and [Quick Start](https://framework.frictionlessdata.io/docs/guides/quick-start)
+> This guide assumes basic familiarity with the Frictionless Framework. To learn more, please read the [Introduction](https://framework.frictionlessdata.io/docs/guides/introduction) and [Quick Start](https://framework.frictionlessdata.io/docs/guides/quick-start).
 
 Transforming data in Frictionless means modifying data and metadata from  state A to state B. For example, it could be a messy Excel file we need to transform to a cleaned CSV file or a folder of data files we want to update and save as a data package.
 
@@ -14,7 +14,7 @@ Frictionless supports a few different kinds of data and metadata transformations
 
 The main difference between these three is that resource and package transforms are imperative while pipelines can be created beforehand or shared as a JSON file.
 
-> Download [`transform.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/transform.csv) into the `data` folder to reproduce the examples
+> Download [`transform.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/transform.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/transform.csv
@@ -75,7 +75,7 @@ There are dozens of other available steps that will be covered below.
 
 Transforming a package is not much more difficult than a resource. Basically, a package is a set of resources so we will be transforming resources exactly the same way as we did above and we will be managing the resources list itself, adding or removing them:
 
-> NOTE: This example is about to be fixed in https://github.com/frictionlessdata/frictionless-py/issues/715
+> NOTE: This example is about to be fixed in https://github.com/frictionlessdata/frictionless-py/issues/715.
 
 ```python title="Python"
 from pprint import pprint
@@ -194,7 +194,7 @@ See [Transform Steps](transform-steps.md) for a list of available steps.
 
 Here is an example of a custom step written as a Python function:
 
-> NOTE: This example is about to be fixed in https://github.com/frictionlessdata/frictionless-py/issues/715
+> NOTE: This example is about to be fixed in https://github.com/frictionlessdata/frictionless-py/issues/715.
 
 ```python title="Python"
 from pprint import pprint
@@ -224,7 +224,7 @@ Learn more about custom steps in the [Step Guide](extension/step-guide.md).
 
 ## Transform Utils
 
-> Transform Utils is under construction
+> Transform Utils is under construction.
 
 ## Working with PETL
 

--- a/docs/guides/transform-steps.md
+++ b/docs/guides/transform-steps.md
@@ -2,11 +2,11 @@
 title: Transform Steps
 ---
 
-> This guide assumes basic familiarity with the Frictionless Framework. To learn more, please read the [Introduction](https://framework.frictionlessdata.io/docs/guides/introduction) and [Quick Start](https://framework.frictionlessdata.io/docs/guides/quick-start)
+> This guide assumes basic familiarity with the Frictionless Framework. To learn more, please read the [Introduction](https://framework.frictionlessdata.io/docs/guides/introduction) and [Quick Start](https://framework.frictionlessdata.io/docs/guides/quick-start).
 
 Frictionless includes more than 40+ built-in transform steps. They are grouped by the object so you can find them easily if you have code auto completion. Start typing, for example, `steps.table...` and you will see all the available steps. The groups are listed below and you will find every group described in more detail in the next sections. It's also possible to write custom transform steps. Please read the section below to learn more about it.  Let's prepare the data that we need to show how the checks below work:
 
-> Download [`transform.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/transform.csv) into the `data` folder to reproduce the examples
+> Download [`transform.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/transform.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/transform.csv
@@ -18,7 +18,7 @@ id,name,population
 3,spain,47
 ```
 
-> Download [`transform-groups.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/transform-groups.csv) into the `data` folder to reproduce the examples
+> Download [`transform-groups.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/transform-groups.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/transform-groups.csv
@@ -33,7 +33,7 @@ id,name,population,year
 6,spain,33,1920
 ```
 
-> Download [`transform-pivot.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/transform-pivot.csv) into the `data` folder to reproduce the examples
+> Download [`transform-pivot.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/transform-pivot.csv) into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/transform-pivot.csv

--- a/docs/guides/validation-checks.md
+++ b/docs/guides/validation-checks.md
@@ -2,7 +2,7 @@
 title: Validation Checks
 ---
 
-> This guide assumes basic familiarity with the Frictionless Framework. To learn more, please read the [Introduction](https://framework.frictionlessdata.io/docs/guides/introduction) and [Quick Start](https://framework.frictionlessdata.io/docs/guides/quick-start)
+> This guide assumes basic familiarity with the Frictionless Framework. To learn more, please read the [Introduction](https://framework.frictionlessdata.io/docs/guides/introduction) and [Quick Start](https://framework.frictionlessdata.io/docs/guides/quick-start).
 
 There are various validation checks included in the core Frictionless Framework along with an ability to create custom checks. Let's review what's in the box.
 

--- a/docs/guides/validation-guide.md
+++ b/docs/guides/validation-guide.md
@@ -2,11 +2,11 @@
 title: Validation Guide
 ---
 
-> This guide assumes basic familiarity with the Frictionless Framework. To learn more, please read the [Introduction](https://framework.frictionlessdata.io/docs/guides/introduction) and [Quick Start](https://framework.frictionlessdata.io/docs/guides/quick-start)
+> This guide assumes basic familiarity with the Frictionless Framework. To learn more, please read the [Introduction](https://framework.frictionlessdata.io/docs/guides/introduction) and [Quick Start](https://framework.frictionlessdata.io/docs/guides/quick-start).
 
 Tabular data validation is a process of identifying tabular problems that have occured in your data so you can correct them. Let's explore how Frictionless helps to achieve this task using an invalid data table example:
 
-> Download [`capital-invalid.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/capital-invalid.csv) and put into the `data` folder to reproduce the examples
+> Download [`capital-invalid.csv`](https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/data/capital-invalid.csv) and put into the `data` folder to reproduce the examples.
 
 ```bash title="CLI"
 cat data/capital-invalid.csv


### PR DESCRIPTION
# Overview

Blockquotes in the guide seem to be intended to end with a period after the last sentence:

> This example assumes that you are familiar with the concepts behind the Frictionless Framework. For an introduction, please read the Introduction.

This PR adds that to blockquotes where it was missing, so it is consistent.

---

Please preserve this line to notify @roll (lead of this repository)
