### PR TITLE
move sentence position at 'Available Checks' section

### DIFF
--- a/docs/guides/validation-guide.md
+++ b/docs/guides/validation-guide.md
@@ -387,7 +387,7 @@ Please explore the "Errors Reference" to learn about all the available errors an
 
 ## Available Checks
 
-> Note that only the Baseline Check is enabled by default. Other built-in checks need to be activated as shown below.
+> Note that only the Baseline Check is enabled by default. Other built-in checks need to be activated as shown below. See [Validation Checks](validation-checks.md) for a list of available checks.
 
 There are various validation checks included in the core Frictionless Framework along with an ability to create custom checks. You can provide a list of checks where individual checks are in the form of:
 - a dict: `{'code': 'code', 'option1': 'value1'}`
@@ -410,7 +410,6 @@ pprint(report.flatten(["rowPosition", "fieldPosition", "code", "note"]))
  [12, 4, 'extra-cell', '']]
 ```
 
-See [Validation Checks](validation-checks.md) for a list of available checks.
 
 ## Custom Checks
 


### PR DESCRIPTION
# Overview

I suggested moving the sentence 'See Validation Checks for a list of available checks.' to the beginning of this section because 'Baseline Checks' was mentioned for the first time and the user has to reach another page to see this content

---

Please preserve this line to notify @roll (lead of this repository)
