### PR TITLE
remove url param from sql docs

### DIFF
--- a/docs/tutorials/formats/sql-tutorial.md
+++ b/docs/tutorials/formats/sql-tutorial.md
@@ -36,7 +36,7 @@ You can write SQL databases:
 from frictionless import Package
 
 package = Package('path/to/datapackage.json')
-package.to_sql(url='postgresql://mydatabase')
+package.to_sql('postgresql://mydatabase')
 ```
 
 


### PR DESCRIPTION
# Overview

Since https://github.com/frictionlessdata/frictionless-py/pull/655 `url` is no longer a named param

---

Please preserve this line to notify @roll (lead of this repository)
