### PR TITLE
Convert to markdown

### DIFF
--- a/frictionless/to_markdown/README.md
+++ b/frictionless/to_markdown/README.md
@@ -1,0 +1,3 @@
+# Frictionless to Markdown
+
+Based on Handlebars templates from https://framagit.org/opendataschema/table-schema-to-markdown/.

--- a/frictionless/to_markdown/datapackage.json
+++ b/frictionless/to_markdown/datapackage.json
@@ -1,0 +1,509 @@
+{
+  "licenses": [
+    {
+      "name": "ODC-PDDL",
+      "path": "http://opendatacommons.org/licenses/pddl/",
+      "title": "Open Data Commons Public Domain Dedication and License"
+    }
+  ],
+  "name": "covid-19",
+  "resources": [
+    {
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "encoding": "ISO-8859-1",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "name": "countries-aggregated",
+      "path": "data/countries-aggregated.csv",
+      "pathType": "local",
+      "schema": {
+        "fields": [
+          {
+            "format": "%Y-%m-%d",
+            "name": "Date",
+            "type": "date"
+          },
+          {
+            "format": "default",
+            "name": "Country",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Confirmed",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Recovered",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Deaths",
+            "type": "integer"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "encoding": "ISO-8859-1",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "name": "reference",
+      "path": "data/reference.csv",
+      "pathType": "local",
+      "schema": {
+        "fields": [
+          {
+            "format": "default",
+            "name": "UID",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "iso2",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "iso3",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "code3",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "FIPS",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Admin2",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Province_State",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Country_Region",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Lat",
+            "type": "number"
+          },
+          {
+            "format": "default",
+            "name": "Long_",
+            "type": "number"
+          },
+          {
+            "format": "default",
+            "name": "Combined_Key",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Population",
+            "type": "integer"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "encoding": "ISO-8859-1",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "name": "key-countries-pivoted",
+      "path": "data/key-countries-pivoted.csv",
+      "pathType": "local",
+      "schema": {
+        "fields": [
+          {
+            "format": "%Y-%m-%d",
+            "name": "Date",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "China",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "US",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "United_Kingdom",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Italy",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "France",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Germany",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Spain",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Iran",
+            "type": "integer"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "encoding": "ISO-8859-1",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "name": "time-series-19-covid-combined",
+      "path": "data/time-series-19-covid-combined.csv",
+      "pathType": "local",
+      "schema": {
+        "fields": [
+          {
+            "format": "%Y-%m-%d",
+            "name": "Date",
+            "type": "date"
+          },
+          {
+            "format": "default",
+            "name": "Country/Region",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Province/State",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Confirmed",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Recovered",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Deaths",
+            "type": "integer"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "encoding": "ISO-8859-9",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "name": "us_confirmed",
+      "path": "data/us_confirmed.csv",
+      "pathType": "local",
+      "schema": {
+        "fields": [
+          {
+            "format": "default",
+            "name": "Admin2",
+            "type": "string"
+          },
+          {
+            "format": "%Y-%m-%d",
+            "name": "Date",
+            "type": "date"
+          },
+          {
+            "format": "default",
+            "name": "Case",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Country/Region",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Province/State",
+            "type": "string"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "encoding": "ISO-8859-9",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "name": "us_deaths",
+      "path": "data/us_deaths.csv",
+      "pathType": "local",
+      "schema": {
+        "fields": [
+          {
+            "format": "default",
+            "name": "Admin2",
+            "type": "string"
+          },
+          {
+            "format": "%Y-%m-%d",
+            "name": "Date",
+            "type": "date"
+          },
+          {
+            "format": "default",
+            "name": "Case",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Country/Region",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Province/State",
+            "type": "string"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "encoding": "ISO-8859-9",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "name": "us_simplified",
+      "path": "data/us_simplified.csv",
+      "pathType": "local",
+      "schema": {
+        "fields": [
+          {
+            "format": "%Y-%m-%d",
+            "name": "Date",
+            "type": "date"
+          },
+          {
+            "format": "default",
+            "name": "Admin2",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Province/State",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Confirmed",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Deaths",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Country/Region",
+            "type": "string"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "encoding": "ISO-8859-2",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "name": "worldwide-aggregate",
+      "path": "data/worldwide-aggregate.csv",
+      "pathType": "local",
+      "schema": {
+        "fields": [
+          {
+            "format": "%Y-%m-%d",
+            "name": "Date",
+            "type": "string"
+          },
+          {
+            "format": "default",
+            "name": "Confirmed",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Recovered",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Deaths",
+            "type": "integer"
+          },
+          {
+            "format": "default",
+            "name": "Increase rate",
+            "type": "number"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    }
+  ],
+  "title": "Novel Coronavirus 2019",
+  "views": [
+    {
+      "resources": [
+        "worldwide-aggregate"
+      ],
+      "spec": {
+        "group": "Date",
+        "series": [
+          "Confirmed",
+          "Deaths"
+        ],
+        "type": "line"
+      },
+      "specType": "simple",
+      "title": "Total world to date"
+    },
+    {
+      "resources": [
+        "key-countries-pivoted"
+      ],
+      "spec": {
+        "group": "Date",
+        "series": [
+          "China",
+          "US",
+          "United_Kingdom",
+          "Italy",
+          "France",
+          "Germany",
+          "Spain",
+          "Iran"
+        ],
+        "type": "line"
+      },
+      "specType": "simple",
+      "title": "Number of confirmed cases in key countries"
+    },
+    {
+      "resources": [
+        {
+          "name": "worldwide-aggregate",
+          "transform": [
+            {
+              "asFields": [
+                "Mortality rate"
+              ],
+              "expressions": [
+                "data['Deaths'] / data['Confirmed'] * 100 + '%'"
+              ],
+              "type": "formula"
+            }
+          ]
+        }
+      ],
+      "spec": {
+        "group": "Date",
+        "series": [
+          "Mortality rate"
+        ],
+        "type": "bar"
+      },
+      "specType": "simple",
+      "title": "Mortality rate in percentage"
+    },
+    {
+      "resources": [
+        "worldwide-aggregate"
+      ],
+      "spec": {
+        "group": "Date",
+        "series": [
+          "Increase rate"
+        ],
+        "type": "bar"
+      },
+      "specType": "simple",
+      "title": "Increase rate from previous day in confirmed cases worldwide"
+    }
+  ]
+}

--- a/frictionless/to_markdown/helpers.py
+++ b/frictionless/to_markdown/helpers.py
@@ -1,0 +1,24 @@
+def formatMarkdownCode(s):
+    return f"`{s}`"
+
+
+def formatMarkdownCodeList(s):
+    return [f"`{x}`" for x in s]
+
+
+def formatMarkdownLinkOrText(text, options):
+    href = options.hash.href
+    return f"[${text}](${href})" if href else text
+
+
+def formatIndent(indent):
+    return "  " if indent else ""
+
+
+helpers = {
+    "formatMarkdownCode": formatMarkdownCode,
+    "formatMarkdownCodeList": formatMarkdownCodeList,
+    "formatMarkdownLinkOrText": formatMarkdownLinkOrText,
+    "formatIndent": formatIndent,
+    "formatMessage": lambda x: x
+}

--- a/frictionless/to_markdown/i18n/en.json
+++ b/frictionless/to_markdown/i18n/en.json
@@ -1,0 +1,88 @@
+{
+  "fieldProperties": {
+    "arrayItem": "array item",
+    "bareNumber": "the number can contain extra characters (e.g. « € », « % » ...)",
+    "constraints": {
+      "enum": "allowed values",
+      "label": "constraints",
+      "maximum": "maximal value",
+      "maxLength": "maximal length",
+      "minimum": "minimal value",
+      "minLength": "minimal length",
+      "notRequired": "optional value",
+      "pattern": "pattern",
+      "required": "required value",
+      "unique": "unique value"
+    },
+    "contributors": {
+      "role": {
+        "author": "author",
+        "contributor": "contributor",
+        "maintainer": "maintainer",
+        "publisher": "publisher",
+        "wrangler": "wrangler"
+      }
+    },
+    "decimalChar": "decimal separator",
+    "description": "description",
+    "example": "example",
+    "falseValues": "values considered false",
+    "groupChar": "digit group separator",
+    "name": "name",
+    "rdfType": "RDF type",
+    "title": "title",
+    "trueValues": "values considered true",
+    "type": "type"
+  },
+  "format": {
+    "email": "email address",
+    "uri": "URI",
+    "binary": "binary data encoded in base64",
+    "uuid": "unique identifier UUID"
+  },
+  "messages": {
+    "dataModel": "Data model",
+    "dataModelIntro": "This data model relies on the {count} following fields corresponding to the columns of the tabular file.",
+    "definitionList": {
+      "key": "{key}:",
+      "keyValue": "{key}: {value}"
+    },
+    "link": "link",
+    "na": "n/a",
+    "schemaImageAlt": "schema image",
+    "unknownRole": "unknown role"
+  },
+  "schemaProperties": {
+    "contributors": "contributors",
+    "created": "creation date",
+    "countryCode": "relates to the country",
+    "homepage": "homepage",
+    "keywords": "keywords",
+    "lastModified": "last modification date",
+    "licenses": "licenses",
+    "missingValues": "missing values represented by",
+    "name": "name",
+    "path": "schema URL",
+    "resources": "resources",
+    "sources": "sources",
+    "version": "version"
+  },
+  "separators": {
+    "inlineEnumeration": ", "
+  },
+  "type": {
+    "array": "array",
+    "boolean": "boolean",
+    "date": "date",
+    "datetime": "date and time",
+    "duration": "duration",
+    "geopoint": "geographical point",
+    "integer": "integer number",
+    "number": "real number",
+    "object": "object",
+    "string": "string",
+    "time": "time",
+    "year": "year",
+    "yearmonth": "year and month"
+  }
+}

--- a/frictionless/to_markdown/i18n/fr.json
+++ b/frictionless/to_markdown/i18n/fr.json
@@ -1,0 +1,88 @@
+{
+  "fieldProperties": {
+    "arrayItem": "élément de liste",
+    "bareNumber": "le nombre peut contenir des caractères supplémentaires (e.g. « € », « % » ...)",
+    "constraints": {
+      "enum": "valeurs autorisées",
+      "label": "contraintes",
+      "maximum": "valeur maximale",
+      "maxLength": "taille maximale",
+      "minimum": "valeur minimale",
+      "minLength": "taille minimale",
+      "notRequired": "valeur optionnelle",
+      "pattern": "motif",
+      "required": "valeur obligatoire",
+      "unique": "valeur unique"
+    },
+    "contributors": {
+      "role": {
+        "author": "auteur",
+        "contributor": "contributeur",
+        "maintainer": "mainteneur",
+        "publisher": "éditeur",
+        "wrangler": "bricoleur"
+      }
+    },
+    "decimalChar": "séparateur décimal",
+    "description": "description",
+    "example": "exemple",
+    "falseValues": "valeurs considérées comme fausses",
+    "groupChar": "séparateur de groupes de chiffres",
+    "name": "nom",
+    "rdfType": "type RDF",
+    "title": "titre",
+    "trueValues": "valeurs considérées comme vraies",
+    "type": "type"
+  },
+  "format": {
+    "email": "adresse de courriel",
+    "uri": "URI",
+    "binary": "données binaires encodées en base64",
+    "uuid": "identifiant unique UUID"
+  },
+  "messages": {
+    "dataModel": "Modèle de données",
+    "dataModelIntro": "Ce modèle de données repose sur les {count} champs suivants correspondant aux colonnes du fichier tabulaire.",
+    "definitionList": {
+      "key": "{key} :",
+      "keyValue": "{key} : {value}"
+    },
+    "link": "lien",
+    "na": "s/o",
+    "schemaImageAlt": "image du schéma",
+    "unknownRole": "rôle inconnu"
+  },
+  "schemaProperties": {
+    "contributors": "contributeurs",
+    "created": "date de création",
+    "countryCode": "concerne le pays",
+    "homepage": "page d'accueil",
+    "keywords": "mots clés",
+    "lastModified": "date de dernière modification",
+    "licenses": "licences",
+    "missingValues": "valeurs manquantes représentées par",
+    "name": "nom",
+    "path": "URL du schéma",
+    "resources": "ressources",
+    "sources": "sources",
+    "version": "version"
+  },
+  "separators": {
+    "inlineEnumeration": ", "
+  },
+  "type": {
+    "array": "liste",
+    "boolean": "booléen",
+    "date": "date",
+    "datetime": "date et heure",
+    "duration": "durée",
+    "geopoint": "point géographique",
+    "integer": "nombre entier",
+    "number": "nombre réel",
+    "object": "objet",
+    "string": "chaîne de caractères",
+    "time": "heure",
+    "year": "année",
+    "yearmonth": "année et mois"
+  }
+}

--- a/frictionless/to_markdown/render.py
+++ b/frictionless/to_markdown/render.py
@@ -1,0 +1,22 @@
+# Get a compiler
+from pybars import Compiler
+compiler = Compiler()
+
+# Compile the template
+source = u""
+template = compiler.compile(source)
+
+
+def intlGet(this, key):
+    pass
+
+helpers = {'list': _list}
+
+# Add partials
+header = compiler.compile(u'<h1>People</h1>')
+partials = {'header': header}
+
+# Render the template
+output = template(data, helpers=helpers, partials=partials)
+
+print(output)

--- a/frictionless/to_markdown/render.py
+++ b/frictionless/to_markdown/render.py
@@ -1,22 +1,62 @@
 # Get a compiler
 from pybars import Compiler
+import json
+import glom
+import os
+from helpers import helpers
+
 compiler = Compiler()
 
+def getText(loc):
+    with open(loc, "r") as file:
+        data = file.read()
+    return data
+
 # Compile the template
-source = u""
+source = getText("./templates/index.hbs")
 template = compiler.compile(source)
+
+lang = "en"
+langLoc = "./i18n/" + lang + ".json"
+print(langLoc)
+intlData = json.loads(getText(langLoc))
 
 
 def intlGet(this, key):
-    pass
+    return glom(intlData, key)
 
-helpers = {'list': _list}
 
-# Add partials
-header = compiler.compile(u'<h1>People</h1>')
-partials = {'header': header}
+# helpers = {'intlGet': intlGet}
+
+partials = {}
+
+
+def loadPartial(location):
+    data = getText(location)
+    p = compiler.compile(data)
+    name = os.path.splitext(location)[0]
+    print(f"loading partial {name}")
+    partials[name] = p
+
+
+ps = [
+    "./templates/partials/fields-as-headings/constraintHeadingProperties.hbs",
+    "./templates/partials/fields-as-table/constraintTableProperties.hbs",
+    "./templates/partials/default/properties.hbs",
+    "./templates/partials/default/property.hbs",
+    "./templates/partials/default/propertyListItemArrayIfValue.hbs",
+    "./templates/partials/default/propertyListItemIfValue.hbs",
+    "./templates/partials/default/titleNamePath.hbs",
+    "./templates/partials/fields-as-headings/schemaField.hbs",
+    "./templates/partials/fields-as-headings/schemaFields.hbs",
+]
+
+for p in ps:
+    loadPartial(p)
+
+data = json.loads("./datapackage.json")
 
 # Render the template
-output = template(data, helpers=helpers, partials=partials)
+output = template(data, helpers={**helpers, **{"intlGet": intlGet}}, partials=partials)
 
 print(output)

--- a/frictionless/to_markdown/templates/index.hbs
+++ b/frictionless/to_markdown/templates/index.hbs
@@ -1,0 +1,17 @@
+# {{{title}}}
+
+{{#if image}}
+![{{formatMessage (intlGet "messages.schemaImageAlt")}}]({{{image}}})
+{{/if}}
+
+{{#if description}}
+{{{description}}}
+{{/if}}
+
+{{> properties }}
+
+## {{ intlGet "messages.dataModel" }}
+
+{{ formatMessage (intlGet "messages.dataModelIntro") count=(formatNumber fields.length) }}
+
+{{> schemaFields }}

--- a/frictionless/to_markdown/templates/partials/default/properties.hbs
+++ b/frictionless/to_markdown/templates/partials/default/properties.hbs
@@ -1,0 +1,46 @@
+{{> propertyListItemIfValue name=(intlGet "schemaProperties.name") value=name ~}}
+
+{{> propertyListItemIfValue name=(intlGet "schemaProperties.homepage") value=homepage ~}}
+
+{{> propertyListItemIfValue name=(intlGet "schemaProperties.path") value=path ~}}
+
+{{> propertyListItemIfValue name=(intlGet "schemaProperties.version") value=version ~}}
+
+{{> propertyListItemIfValue name=(intlGet "schemaProperties.keywords") value=(join keywords (intlGet "separators.inlineEnumeration")) ~}}
+
+{{#if created}}
+- {{> property name=(intlGet "schemaProperties.created") value=(formatDate created)}}
+{{/if ~}}
+
+{{#if lastModified}}
+- {{> property name=(intlGet "schemaProperties.lastModified") value=(formatDate lastModified)}}
+{{/if ~}}
+
+{{> propertyListItemIfValue name=(intlGet "schemaProperties.countryCode") value=countryCode ~}}
+
+{{> propertyListItemIfValue name=(intlGet "schemaProperties.missingValues") value=(formatMarkdownCode (JSONstringify missingValues)) ~}}
+
+{{#> propertyListItemArrayIfValue name=(intlGet "schemaProperties.contributors") values=contributors}}
+{{title ~}}
+{{#if organisation}}
+, {{organisation}}
+{{~/if}}
+{{#if role}}
+ ({{intlGet (append "fieldProperties.contributors.role." role)}})
+{{~/if}}
+{{#if email}}
+ [{{{email}}}]({{{email}}})
+{{~/if}}
+{{/propertyListItemArrayIfValue ~}}
+
+{{#> propertyListItemArrayIfValue name=(intlGet "schemaProperties.licenses") values=licenses}}
+{{> titleNamePath}}
+{{~/propertyListItemArrayIfValue ~}}
+
+{{#> propertyListItemArrayIfValue name=(intlGet "schemaProperties.resources") values=resources}}
+{{> titleNamePath}}
+{{~/propertyListItemArrayIfValue ~}}
+
+{{#> propertyListItemArrayIfValue name=(intlGet "schemaProperties.sources") values=sources}}
+{{> titleNamePath}}
+{{/propertyListItemArrayIfValue}}

--- a/frictionless/to_markdown/templates/partials/default/property.hbs
+++ b/frictionless/to_markdown/templates/partials/default/property.hbs
@@ -1,0 +1,1 @@
+{{{formatMessage (intlGet "messages.definitionList.keyValue") key=name value=value}}}

--- a/frictionless/to_markdown/templates/partials/default/propertyListItemArrayIfValue.hbs
+++ b/frictionless/to_markdown/templates/partials/default/propertyListItemArrayIfValue.hbs
@@ -1,0 +1,6 @@
+{{#if values}}
+- {{{formatMessage (intlGet "messages.definitionList.key") key=name}}}
+{{#each values}}
+  - {{> @partial-block }}
+{{/each}}
+{{/if}}

--- a/frictionless/to_markdown/templates/partials/default/propertyListItemIfValue.hbs
+++ b/frictionless/to_markdown/templates/partials/default/propertyListItemIfValue.hbs
@@ -1,0 +1,3 @@
+{{#if value}}
+- {{> property}}
+{{/if}}

--- a/frictionless/to_markdown/templates/partials/default/titleNamePath.hbs
+++ b/frictionless/to_markdown/templates/partials/default/titleNamePath.hbs
@@ -1,0 +1,7 @@
+{{#if name}}
+{{name ~}},
+{{/if}}
+{{#if title}}
+{{title ~}}
+{{/if}}
+ ({{{formatMarkdownLinkOrText (intlGet "messages.link") href=path}}})

--- a/frictionless/to_markdown/templates/partials/fields-as-headings/constraintHeadingProperties.hbs
+++ b/frictionless/to_markdown/templates/partials/fields-as-headings/constraintHeadingProperties.hbs
@@ -1,0 +1,47 @@
+{{#unless arrayItem}}
+    {{#if constraints.required}}
+- {{{intlGet "fieldProperties.constraints.required"}}}
+    {{else}}
+- {{{intlGet "fieldProperties.constraints.notRequired"}}}
+    {{/if}}
+{{/unless}}
+{{#if constraints.unique}}
+{{ formatIndent arrayItem }}- {{{intlGet "fieldProperties.constraints.unique"}}}
+{{/if}}
+{{#if constraints.minLength}}
+{{ formatIndent arrayItem }}- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+                                  key=(intlGet "fieldProperties.constraints.minLength")
+                                  value=(formatNumber constraints.minLength)
+                              }}}
+{{/if}}
+{{#if constraints.maxLength}}
+{{ formatIndent arrayItem }}- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+                                  key=(intlGet "fieldProperties.constraints.maxLength")
+                                  value=(formatNumber constraints.maxLength)
+                              }}}
+{{/if}}
+{{#if constraints.minimum}}
+{{ formatIndent arrayItem }}- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+                                  key=(intlGet "fieldProperties.constraints.minimum")
+                                  value=(formatNumber constraints.minimum)
+                              }}}
+{{/if}}
+{{#if constraints.maximum}}
+{{ formatIndent arrayItem }}- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+                                  key=(intlGet "fieldProperties.constraints.maximum")
+                                  value=(formatNumber constraints.maximum)
+                              }}}
+{{/if}}
+{{#if constraints.pattern}}
+{{ formatIndent arrayItem }}- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+                                  key=(intlGet "fieldProperties.constraints.pattern")
+                                  value=(formatMarkdownCode constraints.pattern)
+                              }}}
+{{/if}}
+{{#if constraints.enum}}
+{{ formatIndent arrayItem }}- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+                                  key=(intlGet "fieldProperties.constraints.enum")
+                                  value=(join (formatMarkdownCodeList constraints.enum) (intlGet "separators.inlineEnumeration"))
+                              }}}
+{{/if ~}}
+

--- a/frictionless/to_markdown/templates/partials/fields-as-headings/schemaField.hbs
+++ b/frictionless/to_markdown/templates/partials/fields-as-headings/schemaField.hbs
@@ -1,0 +1,68 @@
+### `{{name}}`
+
+- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+      key=(intlGet "fieldProperties.title")
+      value=title
+  }}}
+- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+      key=(intlGet "fieldProperties.description")
+      value=description
+  }}}
+- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+      key=(intlGet "fieldProperties.type")
+      value=(intlGet (append "type." type))
+  }}}{{#isnt format "default"}} ({{format}}){{/isnt}}
+{{#if arrayItem}}
+- {{{formatMessage (intlGet "messages.definitionList.key")
+      key=(intlGet "fieldProperties.arrayItem")
+  }}}
+{{#with arrayItem}}
+{{#if type}}
+{{ formatIndent true }}- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+                             key=(intlGet "fieldProperties.type")
+                             value=(intlGet (append "type." type))
+                         }}}{{#if format}}{{#isnt format "default"}} ({{format}}){{/isnt}}{{/if}}
+{{/if}}
+{{> constraintHeadingProperties constraints=constraints arrayItem=true}}
+{{/with}}
+{{/if}}
+{{#if decimalChar}}
+- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+      key=(intlGet "fieldProperties.decimalChar")
+      value=decimalChar
+  }}}
+{{/if}}
+{{#if groupChar}}
+- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+      key=(intlGet "fieldProperties.groupChar")
+      value=groupChar
+  }}}
+{{/if}}
+{{#if trueValues}}
+- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+      key=(intlGet "fieldProperties.trueValues")
+      value=(join trueValues (intlGet "separators.inlineEnumeration"))
+  }}}
+{{/if}}
+{{#if falseValues}}
+- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+      key=(intlGet "fieldProperties.falseValues")
+      value=(join falseValues (intlGet "separators.inlineEnumeration"))
+  }}}
+{{/if}}
+{{#if bareNumber}}
+- {{{intlGet "fieldProperties.bareNumber"}}}
+{{/if}}
+{{#if rdfType}}
+- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+      key=(intlGet "fieldProperties.rdfType")
+      value=rdfType
+  }}}
+{{/if}}
+{{#if example}}
+- {{{formatMessage (intlGet "messages.definitionList.keyValue")
+      key=(intlGet "fieldProperties.example")
+      value=(formatMarkdownCode example)
+  }}}
+{{/if}}
+{{> constraintHeadingProperties constraints=constraints arrayItem=false}}

--- a/frictionless/to_markdown/templates/partials/fields-as-headings/schemaFields.hbs
+++ b/frictionless/to_markdown/templates/partials/fields-as-headings/schemaFields.hbs
@@ -1,0 +1,4 @@
+{{#each fields}}
+{{> schemaField }}
+
+{{/each}}

--- a/frictionless/to_markdown/templates/partials/fields-as-table/constraintTableProperties.hbs
+++ b/frictionless/to_markdown/templates/partials/fields-as-table/constraintTableProperties.hbs
@@ -1,0 +1,8 @@
+{{#unless arrayItem}}{{~#if constraints.required}}<p>{{intlGet "fieldProperties.constraints.required"}}</p>{{else}}<p>{{intlGet "fieldProperties.constraints.notRequired"}}</p>{{/if}}{{/unless}}
+{{~#if constraints.unique}}<p>{{intlGet "fieldProperties.constraints.unique"}}</p>{{/if}}
+{{~#if constraints.minLength}}<p>{{{formatMessage (intlGet "messages.definitionList.keyValue") key=(intlGet "fieldProperties.constraints.minLength") value=(formatNumber constraints.minLength)}}}</p>{{/if}}
+{{~#if constraints.maxLength}}<p>{{{formatMessage (intlGet "messages.definitionList.keyValue") key=(intlGet "fieldProperties.constraints.maxLength") value=(formatNumber constraints.maxLength)}}}</p>{{/if}}
+{{~#if constraints.minimum}}<p>{{{formatMessage (intlGet "messages.definitionList.keyValue") key=(intlGet "fieldProperties.constraints.minimum") value=(formatNumber constraints.minimum)}}}</p>{{/if}}
+{{~#if constraints.maximum}}<p>{{{formatMessage (intlGet "messages.definitionList.keyValue") key=(intlGet "fieldProperties.constraints.maximum") value=(formatNumber constraints.maximum)}}}</p>{{/if}}
+{{~#if constraints.pattern}}<p>{{{formatMessage (intlGet "messages.definitionList.keyValue") key=(intlGet "fieldProperties.constraints.pattern") value=(formatMarkdownCode constraints.pattern)}}}</p>{{/if}}
+{{~#if constraints.enum}}<p>{{{formatMessage (intlGet "messages.definitionList.keyValue") key=(intlGet "fieldProperties.constraints.enum") value=(join (formatMarkdownCodeList constraints.enum) (intlGet "separators.inlineEnumeration"))}}}</p>{{/if}}

--- a/frictionless/to_markdown/templates/partials/fields-as-table/schemaField.hbs
+++ b/frictionless/to_markdown/templates/partials/fields-as-table/schemaField.hbs
@@ -1,0 +1,18 @@
+`{{name}}`|
+{{~intlGet (append "type." type)}}|
+{{~title}}|
+{{~#if example}}`{{example}}`{{/if}}|{{"\n"~}}
+{{~#if constraints}}{{> constraintTableProperties constraints=constraints arrayItem=false}}{{/if}}|{{"\n"~}}
+{{~#if arrayItem}}
+{{~#with arrayItem}}
+{{~#if type}}
+<p>{{{formatMessage (intlGet "messages.definitionList.keyValue")
+                             key=(intlGet "fieldProperties.type")
+                             value=(intlGet (append "type." type))
+                         }}}{{#if format}}{{#isnt format "default"}} ({{format}}){{/isnt}}{{/if}}</p>{{"\n"~}}
+{{/if}}
+{{> constraintTableProperties constraints=constraints arrayItem=true}}
+{{/with}}
+{{else}}
+<p>{{intlGet "messages.na"}}</p>{{"\n"~}}
+{{/if~}}|

--- a/frictionless/to_markdown/templates/partials/fields-as-table/schemaFields.hbs
+++ b/frictionless/to_markdown/templates/partials/fields-as-table/schemaFields.hbs
@@ -1,0 +1,11 @@
+{{intlGet "fieldProperties.name"}}|
+{{~intlGet "fieldProperties.type"}}|
+{{~intlGet "fieldProperties.title"}}|
+{{~intlGet "fieldProperties.example"}}|
+{{~intlGet "fieldProperties.constraints.label"}}|
+{{~intlGet "fieldProperties.arrayItem"}}
+-|-|-|-|-|-
+{{#each fields}}
+{{> schemaField }}
+
+{{/each}}


### PR DESCRIPTION
# Overview

Based on Handlebars templates from https://framagit.org/opendataschema/table-schema-to-markdown/ (MIT license)

Uses pybars3 to render templates

---

Please preserve this line to notify @roll (lead of this repository)
