### PR TITLE
Use `field_names` instead of `labels` in `Resource.to_petl` for the petl table header

### DIFF
--- a/frictionless/resource.py
+++ b/frictionless/resource.py
@@ -1198,7 +1198,7 @@ class Resource(Metadata):
                         yield from (row.to_list() for row in resource.row_stream)
                         return
                     if not resource.header.missing:
-                        yield resource.header.labels
+                        yield resource.header.field_names
                     yield from (row.cells for row in resource.row_stream)
 
         return ResourceView()

--- a/tests/transform/test_resource.py
+++ b/tests/transform/test_resource.py
@@ -30,6 +30,7 @@ def test_transform_resource():
         {"id": 3, "variable": "population", "value": 47},
     ]
 
+
 def test_transform_resource_rename_move_field():
     source = Resource(path="data/transform.csv")
     source.infer()
@@ -38,14 +39,14 @@ def test_transform_resource_rename_move_field():
         steps=[
             steps.table_normalize(),
             steps.field_update(name="name", new_name="country"),
-            steps.field_move(name="country", position=3)
+            steps.field_move(name="country", position=3),
         ],
     )
     assert target.schema == {
         "fields": [
             {"name": "id", "type": "integer"},
             {"name": "population", "type": "integer"},
-            {"name": "country", "type": "string"}
+            {"name": "country", "type": "string"},
         ]
     }
     assert target.read_rows() == [

--- a/tests/transform/test_resource.py
+++ b/tests/transform/test_resource.py
@@ -41,7 +41,6 @@ def test_transform_resource_rename_move_field():
             steps.field_move(name="country", position=3)
         ],
     )
-    print(target.schema)
     assert target.schema == {
         "fields": [
             {"name": "id", "type": "integer"},

--- a/tests/transform/test_resource.py
+++ b/tests/transform/test_resource.py
@@ -29,3 +29,28 @@ def test_transform_resource():
         {"id": 3, "variable": "name", "value": "spain"},
         {"id": 3, "variable": "population", "value": 47},
     ]
+
+def test_transform_resource_rename_move_field():
+    source = Resource(path="data/transform.csv")
+    source.infer()
+    target = transform(
+        source,
+        steps=[
+            steps.table_normalize(),
+            steps.field_update(name="name", new_name="country"),
+            steps.field_move(name="country", position=3)
+        ],
+    )
+    print(target.schema)
+    assert target.schema == {
+        "fields": [
+            {"name": "id", "type": "integer"},
+            {"name": "population", "type": "integer"},
+            {"name": "country", "type": "string"}
+        ]
+    }
+    assert target.read_rows() == [
+        {"id": 1, "population": 83, "country": "germany"},
+        {"id": 2, "population": 66, "country": "france"},
+        {"id": 3, "population": 47, "country": "spain"},
+    ]


### PR DESCRIPTION
- fixes #953

---

Please preserve this line to notify @roll (lead of this repository)
