### PR TITLE
Allows descriptors that subclass collections.abc.Mapping (including dict)

### DIFF
--- a/frictionless/file.py
+++ b/frictionless/file.py
@@ -1,5 +1,6 @@
 import os
 import glob
+from collections.abc import Mapping
 from pathlib import Path
 from .helpers import cached_property
 from . import settings
@@ -148,7 +149,7 @@ class File:
         # Detect type
         type = "table"
         if not multipart:
-            if memory and isinstance(data, dict):
+            if memory and isinstance(data, Mapping):
                 type = "resource"
                 if data.get("fields") is not None:
                     type = "schema"

--- a/frictionless/metadata.py
+++ b/frictionless/metadata.py
@@ -3,6 +3,7 @@ import json
 import yaml
 import jsonschema
 import stringcase
+from collections.abc import Mapping
 from pathlib import Path
 from operator import setitem
 from functools import partial
@@ -189,7 +190,7 @@ class Metadata(helpers.ControlledDict):
         try:
             if descriptor is None:
                 return {}
-            if isinstance(descriptor, dict):
+            if isinstance(descriptor, Mapping):
                 if not self.metadata_duplicate:
                     return descriptor
                 try:
@@ -279,7 +280,7 @@ class Metadata(helpers.ControlledDict):
 
 def metadata_to_dict(value):
     process = lambda value: value.to_dict() if hasattr(value, "to_dict") else value
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         value = {key: metadata_to_dict(process(value)) for key, value in value.items()}
     elif isinstance(value, list):
         value = [metadata_to_dict(process(value)) for value in value]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -3,6 +3,7 @@ import json
 import yaml
 import pytest
 import zipfile
+from collections.abc import Mapping
 from pathlib import Path
 from frictionless import Package, Resource, Layout, describe_package, helpers
 from frictionless import FrictionlessException
@@ -28,6 +29,28 @@ def test_package():
 
 def test_package_from_dict():
     package = Package({"name": "name", "profile": "data-package"})
+    assert package == {
+        "name": "name",
+        "profile": "data-package",
+    }
+
+
+class NotADict(Mapping):
+    def __init__(self, **kwargs):
+        self.__dict__.update(**kwargs)
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def __iter__(self):
+        return iter(self.__dict__)
+
+    def __len__(self):
+        return len(self.__dict__)
+
+
+def test_package_from_mapping():
+    package = Package(NotADict(name="name", profile="data-package"))
     assert package == {
         "name": "name",
         "profile": "data-package",


### PR DESCRIPTION
- fixes #906 

The main change is a couple replacements of `isinstance(descriptor, dict)` with `isinstance(descriptor, collections.abc.Mapping)`. In the added test, I defined a sublcass of collections.abc.Mapping. If you don't like where I put the class statement, happy to move it around.