### PR TITLE
Validate example field for Schema fields

### DIFF
--- a/frictionless/field.py
+++ b/frictionless/field.py
@@ -289,12 +289,16 @@ class Field(Metadata):
         return self.get("groupChar", settings.DEFAULT_GROUP_CHAR)
 
     @Metadata.property
+    def has_example(self):
+        return self.example != settings.DEFAULT_EXAMPLE
+
+    @Metadata.property
     def example(self):
         """
         Returns:
             any: example value
         """
-        return self.get("example", None)
+        return self.get("example", settings.DEFAULT_EXAMPLE)
 
     # Expand
 

--- a/frictionless/field.py
+++ b/frictionless/field.py
@@ -58,7 +58,7 @@ class Field(Metadata):
         float_number=None,
         decimal_char=None,
         group_char=None,
-        example=None,
+        example=settings.DEFAULT_EXAMPLE,
         # Extra
         schema=None,
     ):
@@ -78,7 +78,8 @@ class Field(Metadata):
         self.setinitial("decimalChar", decimal_char)
         self.setinitial("groupChar", group_char)
         self.setinitial("rdfType", rdf_type)
-        self.setinitial("example", example)
+        if example != settings.DEFAULT_EXAMPLE:
+            self["example"] = example
         self.__schema = schema
         self.__type = None
         super().__init__(descriptor)

--- a/frictionless/field.py
+++ b/frictionless/field.py
@@ -58,6 +58,7 @@ class Field(Metadata):
         float_number=None,
         decimal_char=None,
         group_char=None,
+        example=None,
         # Extra
         schema=None,
     ):
@@ -77,6 +78,7 @@ class Field(Metadata):
         self.setinitial("decimalChar", decimal_char)
         self.setinitial("groupChar", group_char)
         self.setinitial("rdfType", rdf_type)
+        self.setinitial("example", example)
         self.__schema = schema
         self.__type = None
         super().__init__(descriptor)
@@ -285,6 +287,14 @@ class Field(Metadata):
             str: group char
         """
         return self.get("groupChar", settings.DEFAULT_GROUP_CHAR)
+
+    @Metadata.property
+    def example(self):
+        """
+        Returns:
+            any: example value
+        """
+        return self.get("example", None)
 
     # Expand
 

--- a/frictionless/field.py
+++ b/frictionless/field.py
@@ -58,7 +58,7 @@ class Field(Metadata):
         float_number=None,
         decimal_char=None,
         group_char=None,
-        example=settings.DEFAULT_EXAMPLE,
+        example=None,
         # Extra
         schema=None,
     ):
@@ -78,8 +78,7 @@ class Field(Metadata):
         self.setinitial("decimalChar", decimal_char)
         self.setinitial("groupChar", group_char)
         self.setinitial("rdfType", rdf_type)
-        if example != settings.DEFAULT_EXAMPLE:
-            self["example"] = example
+        self.setinitial("example", example)
         self.__schema = schema
         self.__type = None
         super().__init__(descriptor)
@@ -290,16 +289,12 @@ class Field(Metadata):
         return self.get("groupChar", settings.DEFAULT_GROUP_CHAR)
 
     @Metadata.property
-    def has_example(self):
-        return self.example != settings.DEFAULT_EXAMPLE
-
-    @Metadata.property
     def example(self):
         """
         Returns:
             any: example value
         """
-        return self.get("example", settings.DEFAULT_EXAMPLE)
+        return self.get("example", None)
 
     # Expand
 

--- a/frictionless/schema.py
+++ b/frictionless/schema.py
@@ -303,7 +303,7 @@ class Schema(Metadata):
                 yield from field.metadata_errors
 
         # Examples
-        for field in [f for f in self.fields if field.example]:
+        for field in [f for f in self.fields if field.has_example]:
             _, notes = field.read_cell(field.example)
             if notes is not None:
                 note = 'example value for field "%s" is not valid' % field.name

--- a/frictionless/schema.py
+++ b/frictionless/schema.py
@@ -303,7 +303,7 @@ class Schema(Metadata):
                 yield from field.metadata_errors
 
         # Examples
-        for field in [f for f in self.fields if field.has_example]:
+        for field in [f for f in self.fields if "example" in field]:
             _, notes = field.read_cell(field.example)
             if notes is not None:
                 note = 'example value for field "%s" is not valid' % field.name

--- a/frictionless/schema.py
+++ b/frictionless/schema.py
@@ -302,6 +302,13 @@ class Schema(Metadata):
             if field.builtin:
                 yield from field.metadata_errors
 
+        # Examples
+        for field in [f for f in self.fields if field.example]:
+            _, notes = field.read_cell(field.example)
+            if notes is not None:
+                note = 'example value for field "%s" is not valid' % field.name
+                yield errors.SchemaError(note=note)
+
         # Primary Key
         for name in self.primary_key:
             if name not in self.field_names:

--- a/frictionless/settings.py
+++ b/frictionless/settings.py
@@ -83,6 +83,7 @@ DEFAULT_CANDIDATES = [
     {"type": "year"},
     {"type": "string"},
 ]
+DEFAULT_EXAMPLE = "@@default-dummy-example@@"
 
 
 # Backports

--- a/frictionless/settings.py
+++ b/frictionless/settings.py
@@ -83,7 +83,6 @@ DEFAULT_CANDIDATES = [
     {"type": "year"},
     {"type": "string"},
 ]
-DEFAULT_EXAMPLE = "@@default-dummy-example@@"
 
 
 # Backports

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -22,7 +22,6 @@ def test_field():
     assert field.missing_values == ["-"]
     assert field.constraints == {"required": True}
     assert field.required is True
-    assert not field.has_example
 
 
 def test_field_defaults():
@@ -325,7 +324,6 @@ def test_field_read_cell_multiple_constraints():
 @pytest.mark.parametrize("example_value", [(None), (42), ("foo")])
 def test_field_with_example_set(example_value):
     field = Field({"name": "name", "type": "string", "example": example_value})
-    assert field.has_example
     assert field.example == example_value
 
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -22,6 +22,7 @@ def test_field():
     assert field.missing_values == ["-"]
     assert field.constraints == {"required": True}
     assert field.required is True
+    assert not field.has_example
 
 
 def test_field_defaults():
@@ -319,6 +320,13 @@ def test_field_read_cell_multiple_constraints():
     )
     # Null value passes
     assert read("") == (None, None)
+
+
+@pytest.mark.parametrize("example_value", [(None), (42), ("foo")])
+def test_field_with_example_set(example_value):
+    field = Field({"name": "name", "type": "string", "example": example_value})
+    assert field.has_example
+    assert field.example == example_value
 
 
 # Import/Export

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -255,6 +255,13 @@ def test_schema_metadata_error_message():
     assert "is not valid under any of the given schema" in note
 
 
+def test_schema_invalid_example():
+    schema = Schema({"fields": [{"name": "name", "type": "string", "example": 42}]})
+    note = schema.metadata_errors[0]["note"]
+    assert len(schema.metadata_errors) == 1
+    assert 'example value for field "name" is not valid' == note
+
+
 @pytest.mark.parametrize("create_descriptor", [(False,), (True,)])
 def test_schema_standard_specs_properties(create_descriptor):
     options = dict(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -264,11 +264,23 @@ def test_schema_valid_examples():
             ]
         }
     )
+    assert schema.get_field("name").example == "John"
     assert len(schema.metadata_errors) == 0
 
 
 def test_schema_invalid_example():
-    schema = Schema({"fields": [{"name": "name", "type": "string", "example": 42}]})
+    schema = Schema(
+        {
+            "fields": [
+                {
+                    "name": "name",
+                    "type": "string",
+                    "example": None,
+                    "constraints": {"required": True},
+                }
+            ]
+        }
+    )
     note = schema.metadata_errors[0]["note"]
     assert len(schema.metadata_errors) == 1
     assert 'example value for field "name" is not valid' == note

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -255,6 +255,18 @@ def test_schema_metadata_error_message():
     assert "is not valid under any of the given schema" in note
 
 
+def test_schema_valid_examples():
+    schema = Schema(
+        {
+            "fields": [
+                {"name": "name", "type": "string", "example": "John"},
+                {"name": "age", "type": "integer", "example": 42},
+            ]
+        }
+    )
+    assert len(schema.metadata_errors) == 0
+
+
 def test_schema_invalid_example():
     schema = Schema({"fields": [{"name": "name", "type": "string", "example": 42}]})
     note = schema.metadata_errors[0]["note"]


### PR DESCRIPTION
- fixes #997 

---

An attempt at validating an optional `example` value for a `Field`. If it is present, make sure it matches types/constraints etc.
