### PR TITLE
chore(ci): produce xml report for Codecov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ test:
 
 test-ci:
 	make lint
-	pytest --cov ${PACKAGE} --cov-report term-missing --cov-fail-under 80 --timeout=300 --ci
+	pytest --cov ${PACKAGE} --cov-report term-missing --cov-report xml --cov-fail-under 80 --timeout=300 --ci


### PR DESCRIPTION
Hi, Tom from Codecov again. I noticed that you weren't getting any status checks (despite the previous [PR](https://github.com/frictionlessdata/frictionless-py/pull/1041)) due to an issue with [processing coverage report](https://codecov.io/github/frictionlessdata/frictionless-py/commit/9c4fdb49ca799c58ee54494421b89ab0c3dd9018). The reason being that Codecov cannot consume the `term-missing` report. I believe this will fix the issue.