### PR TITLE
899/fixes warnings

### DIFF
--- a/frictionless/plugins/excel.py
+++ b/frictionless/plugins/excel.py
@@ -5,6 +5,7 @@ import atexit
 import hashlib
 import tempfile
 import datetime
+import warnings
 from itertools import chain
 from ..exception import FrictionlessException
 from ..metadata import Metadata
@@ -211,6 +212,7 @@ class XlsxParser(Parser):
         # To fill merged cells we can't use read-only because
         # `sheet.merged_cell_ranges` is not available in this mode
         try:
+            warnings.filterwarnings("ignore", category=UserWarning, module="openpyxl")
             book = openpyxl.load_workbook(
                 self.loader.byte_stream,
                 read_only=not dialect.fill_merged_cells,

--- a/tests/plugins/test_excel.py
+++ b/tests/plugins/test_excel.py
@@ -106,18 +106,16 @@ def test_xlsx_parser_adjust_floating_point_error():
         adjust_floating_point_error=True,
     )
     layout = Layout(skip_fields=["<blank>"])
-    with pytest.warns(UserWarning):
-        with Resource(source, dialect=dialect, layout=layout) as resource:
-            assert resource.read_rows()[1].cells[2] == 274.66
+    with Resource(source, dialect=dialect, layout=layout) as resource:
+        assert resource.read_rows()[1].cells[2] == 274.66
 
 
 def test_xlsx_parser_adjust_floating_point_error_default():
     source = "data/adjust-floating-point-error.xlsx"
     dialect = ExcelDialect(preserve_formatting=True)
     layout = Layout(skip_fields=["<blank>"])
-    with pytest.warns(UserWarning):
-        with Resource(source, dialect=dialect, layout=layout) as resource:
-            assert resource.read_rows()[1].cells[2] == 274.65999999999997
+    with Resource(source, dialect=dialect, layout=layout) as resource:
+        assert resource.read_rows()[1].cells[2] == 274.65999999999997
 
 
 def test_xlsx_parser_preserve_formatting():

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -2651,11 +2651,8 @@ def test_resource_skip_rows_non_string_cell_issue_320():
     source = "data/issue-320.xlsx"
     dialect = ExcelDialect(fill_merged_cells=True)
     layout = Layout(header_rows=[10, 11, 12])
-    with pytest.warns(UserWarning):
-        with Resource(source, dialect=dialect, layout=layout) as resource:
-            assert (
-                resource.header[7] == "Current Population Analysed % of total county Pop"
-            )
+    with Resource(source, dialect=dialect, layout=layout) as resource:
+        assert resource.header[7] == "Current Population Analysed % of total county Pop"
 
 
 def test_resource_skip_rows_non_string_cell_issue_322():

--- a/tests/types/test_date.py
+++ b/tests/types/test_date.py
@@ -40,10 +40,9 @@ from frictionless import Field
         ("fmt:%d/%m/%y", "", None),
     ],
 )
-def test_date_read_cell(format, source, target):
-    with pytest.warns(None) as recorded:
-        field = Field({"name": "name", "type": "date", "format": format})
-        cell, notes = field.read_cell(source)
-        assert cell == target
+def test_date_read_cell(format, source, target, recwarn):
+    field = Field({"name": "name", "type": "date", "format": format})
+    cell, notes = field.read_cell(source)
+    assert cell == target
     if not format.startswith("fmt:"):
-        assert recorded.list == []
+        assert recwarn.list == []

--- a/tests/types/test_datetime.py
+++ b/tests/types/test_datetime.py
@@ -54,10 +54,9 @@ from frictionless import Field
         ("fmt:%d/%m/%y %H:%M", "", None),
     ],
 )
-def test_datetime_read_cell(format, source, target):
-    with pytest.warns(None) as recorded:
-        field = Field({"name": "name", "type": "datetime", "format": format})
-        cell, notes = field.read_cell(source)
-        assert cell == target
+def test_datetime_read_cell(format, source, target, recwarn):
+    field = Field({"name": "name", "type": "datetime", "format": format})
+    cell, notes = field.read_cell(source)
+    assert cell == target
     if not format.startswith("fmt:"):
-        assert recorded.list == []
+        assert recwarn.list == []

--- a/tests/types/test_time.py
+++ b/tests/types/test_time.py
@@ -49,10 +49,9 @@ from frictionless import Field
         ("fmt:%H:%M", "", None),
     ],
 )
-def test_time_read_cell(format, source, target):
-    with pytest.warns(None) as recorded:
-        field = Field({"name": "name", "type": "time", "format": format})
-        cell, notes = field.read_cell(source)
-        assert cell == target
+def test_time_read_cell(format, source, target, recwarn):
+    field = Field({"name": "name", "type": "time", "format": format})
+    cell, notes = field.read_cell(source)
+    assert cell == target
     if not format.startswith("fmt:"):
-        assert recorded.list == []
+        assert recwarn.list == []


### PR DESCRIPTION
- Fixes warnings for test_date, test_time, test_datetime
- fixes #899

---

I have fixed other user warnings. But for excel I am thinking of different solutions but need your suggestions on it:

If I disable all userwarnings for openpyxl here([excel.py](http://excel.py/)) in line 215
```
warnings.filterwarnings('ignore', category=UserWarning, module='openpyxl')
```
https://github.com/frictionlessdata/frictionless-py/blob/main/frictionless/plugins/excel.py#L214

One of our tests fail here:
https://github.com/frictionlessdata/frictionless-py/blob/main/tests/test_resource.py#L2654

It is because it is expecting a user warning here. But I think the test is trying to check if it can skip non text cell. So if we change the code to:
```
def test_resource_skip_rows_non_string_cell_issue_320():
    source = "data/issue-320.xlsx"
    dialect = ExcelDialect(fill_merged_cells=True)
    layout = Layout(header_rows=[10, 11, 12])
    # with pytest.warns(UserWarning):
    with Resource(source, dialect=dialect, layout=layout) as resource:
        assert (
            resource.header[7] == "Current Population Analysed % of total county Pop"
        )
```
it works and it also does not change its meaning. And all our tests will pass.

Thank you!
