### PR TITLE
Fix import in Pandas tutorial

### DIFF
--- a/docs/tutorials/formats/pandas-tutorial.md
+++ b/docs/tutorials/formats/pandas-tutorial.md
@@ -17,7 +17,7 @@ pip install 'frictionless[pandas]' # for zsh shell
 You can read a Pandas dataframe:
 
 ```python title="Python"
-from frictionless import Package
+from frictionless import Resource
 
 resource = Resource(df)
 pprint(resource.read_rows())


### PR DESCRIPTION
the `Package` class was imported, but the `Resource` class was being used.

- fixes #1091 

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
