### PR TITLE
Added support for TZ data for the Pandas plugin

### DIFF
--- a/frictionless/plugins/pandas/parser.py
+++ b/frictionless/plugins/pandas/parser.py
@@ -126,8 +126,6 @@ class PandasParser(Parser):
                     if value is None and field.type in ("number", "integer"):
                         fixed_types[field.name] = "number"
                         value = np.NaN
-                    if field.type in ["datetime", "time"] and value is not None:
-                        value = value.replace(tzinfo=None)
                     if field.name in source.schema.primary_key:
                         index_values.append(value)
                     else:
@@ -154,17 +152,13 @@ class PandasParser(Parser):
                 )
 
         # Create dtypes/columns
-        dtypes = []
         columns = []
         for field in source.schema.fields:
             if field.name not in source.schema.primary_key:
-                dtype = self.__write_convert_type(fixed_types.get(field.name, field.type))
-                dtypes.append((field.name, dtype))
                 columns.append(field.name)
 
         # Create/set dataframe
-        array = np.array(data_rows, dtype=dtypes)
-        dataframe = pd.DataFrame(array, index=index, columns=columns)
+        dataframe = pd.DataFrame(data_rows, index=index, columns=columns)
         target.data = dataframe
 
     def __write_convert_type(self, type=None):

--- a/tests/plugins/pandas/test_parser.py
+++ b/tests/plugins/pandas/test_parser.py
@@ -1,6 +1,8 @@
 import pytz
 import isodate
 import datetime
+from dateutil.tz import tzutc
+from dateutil.tz import tzoffset
 import pandas as pd
 from decimal import Decimal
 from frictionless import Package, Resource
@@ -129,9 +131,22 @@ def test_pandas_parser_write_timezone():
         # Assert rows
         assert target.read_rows() == [
             {"datetime": datetime.datetime(2020, 1, 1, 15), "time": datetime.time(15)},
-            {"datetime": datetime.datetime(2020, 1, 1, 15), "time": datetime.time(15)},
-            {"datetime": datetime.datetime(2020, 1, 1, 15), "time": datetime.time(15)},
-            {"datetime": datetime.datetime(2020, 1, 1, 15), "time": datetime.time(15)},
+            {
+                "datetime": datetime.datetime(2020, 1, 1, 15, 0, tzinfo=tzutc()),
+                "time": datetime.time(15, 0, tzinfo=tzutc()),
+            },
+            {
+                "datetime": datetime.datetime(
+                    2020, 1, 1, 15, 0, tzinfo=tzoffset(None, 10800)
+                ),
+                "time": datetime.time(15, 0, tzinfo=tzoffset(None, 10800)),
+            },
+            {
+                "datetime": datetime.datetime(
+                    2020, 1, 1, 15, 0, tzinfo=tzoffset(None, -10800)
+                ),
+                "time": datetime.time(15, 0, tzinfo=tzoffset(None, -10800)),
+            },
         ]
 
 


### PR DESCRIPTION
- fixes #799

Currently we are convert a tabular resource data to a numpy array and then passing it to pandas.Dataframe constructor. The problem is that the numpy array datetime type has no support to timezone  https://numpy.org/doc/stable/reference/arrays.datetime.html

> Deprecated since version 1.11.0: NumPy does not store timezone information. For backwards compatibility, datetime64 still parses timezone offsets, which it handles by converting to UTC. This behaviour is deprecated and will raise an error in the future.

I removed the convert step to numpy array, passing directly the data_rows to the Dataframe constructor and the timezone information was not lost, but converted to a timezone offset. Even for mixed timezones, the information was there. But now some of the tests for the plugin is failing and I'm looking at why.