### PR TITLE
[WIP] Proof of concept: catching all exceptions immediately

### DIFF
--- a/frictionless/actions/transform.py
+++ b/frictionless/actions/transform.py
@@ -85,6 +85,8 @@ def transform_package(source=None, *, steps, deprecate=True, **options):
         try:
             step.transform_package(package)
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.StepError(note=f'"{get_name(step)}" raises "{exception}"')
             raise FrictionlessException(error) from exception
 
@@ -163,6 +165,8 @@ def transform_resource(source=None, *, steps, deprecate=True, **options):
         try:
             step.transform_resource(resource)
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.StepError(note=f'"{get_name(step)}" raises "{exception}"')
             raise FrictionlessException(error) from exception
 
@@ -201,8 +205,13 @@ class DataWithErrorHandling:
         try:
             yield from self.data() if callable(self.data) else self.data
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             if isinstance(exception, FrictionlessException):
                 if exception.error.code == "step-error":
                     raise
             error = errors.StepError(note=f'"{get_name(self.step)}" raises "{exception}"')
             raise FrictionlessException(error) from exception
+
+
+import os

--- a/frictionless/actions/validate.py
+++ b/frictionless/actions/validate.py
@@ -119,6 +119,8 @@ def validate_package(
         for resource in package.resources:
             package_stats.append({key: val for key, val in resource.stats.items() if val})
     except FrictionlessException as exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         return Report(time=timer.time, errors=[exception.error], tasks=[])
 
     # Validate metadata
@@ -219,6 +221,8 @@ def validate_resource(
         stats = {key: val for key, val in resource.stats.items() if val}
         original_resource = resource.to_copy()
     except FrictionlessException as exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         errors.append(exception.error)
 
     # Open resource
@@ -226,6 +230,8 @@ def validate_resource(
         try:
             resource.open()
         except FrictionlessException as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             errors.append(exception.error)
             resource.close()
 
@@ -340,6 +346,8 @@ def validate_schema(source=None, deprecate=True, **options):
         native = isinstance(source, Schema)
         schema = source.to_copy() if native else Schema(source, **options)
     except FrictionlessException as exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         return Report(time=timer.time, errors=[exception.error], tasks=[])
 
     # Return report
@@ -398,3 +406,6 @@ class ManagedErrors(list):
             if Error.code in self.__scope:
                 continue
             self.__scope.append(Error.code)
+
+
+import os

--- a/frictionless/checks/cell/deviated_cell.py
+++ b/frictionless/checks/cell/deviated_cell.py
@@ -59,6 +59,8 @@ class deviated_cell(Check):
                 average = statistics.median(col_cell_sizes.values())
                 maximum = average + stdev * self.__interval
             except Exception as exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 note = 'calculation issue "%s"' % exception
                 yield errors.DeviatedCellError(note=note)
             # Use threshold or maximum value whichever is higher
@@ -78,3 +80,6 @@ class deviated_cell(Check):
             "interval": {"type": ["number", "null"]},
         },
     }
+
+
+import os

--- a/frictionless/checks/cell/deviated_value.py
+++ b/frictionless/checks/cell/deviated_value.py
@@ -70,6 +70,8 @@ class deviated_value(Check):
             minimum = average - stdev * self.__interval
             maximum = average + stdev * self.__interval
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             note = 'calculation issue "%s"' % exception
             yield errors.DeviatedValueError(note=note)
 
@@ -102,3 +104,4 @@ AVERAGE_FUNCTIONS = {
     "median": statistics.median,
     "mode": statistics.mode,
 }
+import os

--- a/frictionless/checks/cell/sequential_value.py
+++ b/frictionless/checks/cell/sequential_value.py
@@ -44,6 +44,8 @@ class sequential_value(Check):
                 assert self.__cursor == cell
                 self.__cursor += 1
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 self.__exited = True
                 yield errors.SequentialValueError.from_row(
                     row,
@@ -58,3 +60,6 @@ class sequential_value(Check):
         "requred": ["fieldName"],
         "properties": {"fieldName": {"type": "string"}},
     }
+
+
+import os

--- a/frictionless/checks/row/row_constraint.py
+++ b/frictionless/checks/row/row_constraint.py
@@ -39,6 +39,8 @@ class row_constraint(Check):
             evalclass = simpleeval.EvalWithCompoundTypes
             assert evalclass(names=row).eval(self.__formula)
         except Exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             yield errors.RowConstraintError.from_row(
                 row,
                 note='the row constraint to conform is "%s"' % self.__formula,
@@ -51,3 +53,6 @@ class row_constraint(Check):
         "requred": ["formula"],
         "properties": {"formula": {"type": "string"}},
     }
+
+
+import os

--- a/frictionless/detector.py
+++ b/frictionless/detector.py
@@ -72,6 +72,8 @@ class Detector:
         schema_patch? (dict): A dictionary to be used as an inferred schema patch.
             The form of this dictionary should follow the Schema descriptor form
             except for the `fields` property which should be a mapping with the
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
             key named after a field name and the values being a field patch.
             For more information, please check "Extracting Data" guide.
     """

--- a/frictionless/field.py
+++ b/frictionless/field.py
@@ -449,6 +449,8 @@ class Field(Metadata):
         try:
             self.__type = system.create_type(self)
         except FrictionlessException:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             self.__type = types.AnyType(self)
 
     def metadata_validate(self):
@@ -499,6 +501,8 @@ def check_minimum(constraint, cell):
         if cell >= constraint:
             return True
     except decimal.InvalidOperation:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         # For non-finite numbers NaN, INF and -INF
         # the constraint always is not satisfied
         return False
@@ -512,6 +516,8 @@ def check_maximum(constraint, cell):
         if cell <= constraint:
             return True
     except decimal.InvalidOperation:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         # For non-finite numbers NaN, INF and -INF
         # the constraint always is not satisfied
         return False
@@ -536,3 +542,4 @@ def check_enum(constraint, cell):
 
 
 COMPILED_RE = type(re.compile(""))
+import os

--- a/frictionless/helpers.py
+++ b/frictionless/helpers.py
@@ -84,6 +84,8 @@ def import_from_plugin(name, *, plugin):
     try:
         return import_module(name)
     except ImportError:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         module = import_module("frictionless.exception")
         errors = import_module("frictionless.errors")
         error = errors.GeneralError(note=f'Please install "frictionless[{plugin}]"')
@@ -276,6 +278,8 @@ def parse_csv_string(string, *, convert=str, fallback=False):
             try:
                 cell = convert(cell)
             except ValueError:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 if not fallback:
                     raise
                 pass
@@ -323,6 +327,8 @@ def md_to_html(md):
         html = html.replace("\n", "")
         return html
     except Exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         return ""
 
 
@@ -366,6 +372,8 @@ def get_current_memory_usage():
                 if key == "rss":
                     return int(parts[1]) / 1000
     except Exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         pass
 
 
@@ -513,6 +521,8 @@ class cached_property:
         try:
             cache = instance.__dict__
         except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             msg = (
                 f"No '__dict__' attribute on {type(instance).__name__!r} "
                 f"instance to cache {self.attrname!r} property."
@@ -528,6 +538,8 @@ class cached_property:
                     try:
                         cache[self.attrname] = val
                     except TypeError:
+                        if os.environ.get("DEBUG", 0) == "1":
+                            raise
                         msg = (
                             f"The '__dict__' attribute on {type(instance).__name__!r} instance "
                             f"does not support item assignment for caching {self.attrname!r} property."
@@ -626,6 +638,8 @@ def dicts_to_markdown_table(dicts: List[dict], **kwargs) -> str:
         pandas = import_module("pandas")
         df = pandas.DataFrame(dicts)
     except ImportError:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         module = import_module("frictionless.exception")
         errors = import_module("frictionless.errors")
         error = errors.GeneralError(note="Please install `pandas` package")

--- a/frictionless/loader.py
+++ b/frictionless/loader.py
@@ -95,6 +95,8 @@ class Loader:
             self.__byte_stream = self.read_byte_stream()
             return self
         except Exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             self.close()
             raise
 
@@ -129,12 +131,18 @@ class Loader:
             self.read_byte_stream_analyze(buffer)
             self.__buffer = buffer
         except (LookupError, UnicodeDecodeError) as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.EncodingError(note=str(exception))
             raise FrictionlessException(error) from exception
         except settings.COMPRESSION_EXCEPTIONS as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.CompressionError(note=str(exception))
             raise FrictionlessException(error)
         except IOError as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.SchemeError(note=str(exception))
             raise FrictionlessException(error)
         return byte_stream
@@ -298,6 +306,8 @@ class ByteStreamWithStatsHandling:
         try:
             self.__hasher = hashlib.new(resource.hashing) if resource.hashing else None
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.HashingError(note=str(exception))
             raise FrictionlessException(error)
 

--- a/frictionless/metadata.py
+++ b/frictionless/metadata.py
@@ -131,6 +131,8 @@ class Metadata(helpers.ControlledDict):
             try:
                 helpers.write_file(path, text)
             except Exception as exc:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 raise FrictionlessException(self.__Error(note=str(exc))) from exc
         return text
 
@@ -153,6 +155,8 @@ class Metadata(helpers.ControlledDict):
             try:
                 helpers.write_file(path, text)
             except Exception as exc:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 raise FrictionlessException(self.__Error(note=str(exc))) from exc
         return text
 
@@ -177,6 +181,8 @@ class Metadata(helpers.ControlledDict):
             try:
                 helpers.write_file(path, md_output)
             except Exception as exc:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 raise FrictionlessException(self.__Error(note=str(exc))) from exc
         return md_output
 
@@ -231,6 +237,8 @@ class Metadata(helpers.ControlledDict):
                 try:
                     return metadata_to_dict(descriptor)
                 except Exception:
+                    if os.environ.get("DEBUG", 0) == "1":
+                        raise
                     note = "descriptor is not serializable"
                     errors = import_module("frictionless.errors")
                     raise FrictionlessException(errors.GeneralError(note=note))
@@ -254,6 +262,8 @@ class Metadata(helpers.ControlledDict):
                 return metadata
             raise TypeError("descriptor type is not supported")
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             note = f'cannot extract metadata "{descriptor}" because "{exception}"'
             raise FrictionlessException(self.__Error(note=note)) from exception
 
@@ -334,3 +344,6 @@ def metadata_attach(self, name, value):
 class IndentDumper(yaml.SafeDumper):
     def increase_indent(self, flow=False, indentless=False):
         return super().increase_indent(flow, False)
+
+
+import os

--- a/frictionless/package/actions/transform.py
+++ b/frictionless/package/actions/transform.py
@@ -46,7 +46,12 @@ def transform(package: "Package", *, steps):
         try:
             step.transform_package(package)
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.StepError(note=f'"{get_name(step)}" raises "{exception}"')
             raise FrictionlessException(error) from exception
 
     return package
+
+
+import os

--- a/frictionless/package/actions/validate.py
+++ b/frictionless/package/actions/validate.py
@@ -36,6 +36,8 @@ def validate(package: "Package", original=False, parallel=False, **options):
         for resource in package.resources:
             package_stats.append({key: val for key, val in resource.stats.items() if val})
     except FrictionlessException as exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         return Report(time=timer.time, errors=[exception.error], tasks=[])
 
     # Validate metadata
@@ -76,3 +78,6 @@ def validate(package: "Package", original=False, parallel=False, **options):
                 )
             )
         return inquiry.run(parallel=parallel)
+
+
+import os

--- a/frictionless/package/package.py
+++ b/frictionless/package/package.py
@@ -665,6 +665,8 @@ class Package(Metadata):
                 )
 
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.PackageError(note=str(exception))
             raise FrictionlessException(error) from exception
 

--- a/frictionless/parser.py
+++ b/frictionless/parser.py
@@ -76,6 +76,8 @@ class Parser:
             self.__list_stream = self.read_list_stream()
             return self
         except Exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             self.close()
             raise
 
@@ -173,15 +175,28 @@ class ListStreamWithErrorHandling:
         try:
             return self.list_stream.__next__()
         except StopIteration:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             raise
         except FrictionlessException:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             raise
         except settings.COMPRESSION_EXCEPTIONS as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.CompressionError(note=str(exception))
             raise FrictionlessException(error)
         except UnicodeDecodeError as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.EncodingError(note=str(exception))
             raise FrictionlessException(error) from exception
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.SourceError(note=str(exception))
             raise FrictionlessException(error) from exception
+
+
+import os

--- a/frictionless/pipeline/pipeline.py
+++ b/frictionless/pipeline/pipeline.py
@@ -143,6 +143,8 @@ class PipelineTask(Metadata):
             transform = import_module("frictionless").transform
             target = transform(self.source, type=self.type, steps=self.steps)
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             errors.append(TaskError(note=str(exception)))
         task = StatusTask(time=timer.time, errors=errors, target=target, type=self.type)
         return Status(tasks=[task], time=timer.time, errors=[])
@@ -174,3 +176,6 @@ def run_task_in_parallel(task_descriptor):
     status = task.run()
     status_descriptor = status.to_dict()
     return status_descriptor
+
+
+import os

--- a/frictionless/plugins/bigquery/storage.py
+++ b/frictionless/plugins/bigquery/storage.py
@@ -78,6 +78,8 @@ class BigqueryStorage(Storage):
                 .execute()
             )
         except google_errors.HttpError:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             note = f'Resource "{name}" does not exist'
             raise FrictionlessException(errors.StorageError(note=note))
 
@@ -292,6 +294,8 @@ class BigqueryStorage(Storage):
         try:
             self.__write_convert_data_finish_job(response)
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             if "not found: job" in str(exception).lower():
                 note = "BigQuery plugin supports only the US location of datasets"
                 raise FrictionlessException(errors.StorageError(note=note))
@@ -384,3 +388,6 @@ def _uncast_value(value, field):
     else:
         value = str(value)
     return value
+
+
+import os

--- a/frictionless/plugins/ckan/storage.py
+++ b/frictionless/plugins/ckan/storage.py
@@ -74,6 +74,8 @@ class CkanStorage(Storage):
                 resource = self.read_resource(name)
             # We skip not tabular resources
             except FrictionlessException as exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 if not exception.error.note.count("Not Found Error"):
                     raise
             package.resources.append(resource)
@@ -323,6 +325,8 @@ def get_ckan_error(response):
         if not response["success"] and response["error"]:
             ckan_error = response["error"]
     except TypeError:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         ckan_error = response
 
     return ckan_error

--- a/frictionless/plugins/csv/parser.py
+++ b/frictionless/plugins/csv/parser.py
@@ -35,6 +35,8 @@ class CsvParser(Parser):
         try:
             dialect = csv.Sniffer().sniff("".join(sample), delimiter)
         except csv.Error:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             dialect = csv.excel()
         for name in INFER_DIALECT_NAMES:
             value = getattr(dialect, name.lower())
@@ -91,6 +93,8 @@ def extract_samle(text_stream):
         try:
             sample.append(next(text_stream))
         except StopIteration:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             break
         if len(sample) >= INFER_DIALECT_VOLUME:
             break
@@ -101,3 +105,4 @@ def extract_samle(text_stream):
 
 # https://stackoverflow.com/a/54515177
 csv.field_size_limit(settings.FIELD_SIZE_LIMIT)
+import os

--- a/frictionless/plugins/excel/parser/xls.py
+++ b/frictionless/plugins/excel/parser/xls.py
@@ -44,6 +44,8 @@ class XlsParser(Parser):
                 logfile=sys.stderr,
             )
         except NotImplementedError:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             book = xlrd.open_workbook(
                 file_contents=bytes,
                 encoding_override=self.resource.encoding,
@@ -58,6 +60,8 @@ class XlsParser(Parser):
             else:
                 sheet = book.sheet_by_index(dialect.sheet - 1)
         except (xlrd.XLRDError, IndexError):
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             note = 'Excel document "%s" does not have a sheet "%s"'
             error = errors.FormatError(
                 note=note % (self.resource.fullpath, dialect.sheet)
@@ -121,3 +125,6 @@ class XlsParser(Parser):
         book.save(file.name)
         loader = system.create_loader(target)
         loader.write_byte_stream(file.name)
+
+
+import os

--- a/frictionless/plugins/excel/parser/xlsx.py
+++ b/frictionless/plugins/excel/parser/xlsx.py
@@ -84,6 +84,8 @@ class XlsxParser(Parser):
                 data_only=True,
             )
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.FormatError(note=f'invalid excel file "{self.resource.path}"')
             raise FrictionlessException(error) from exception
 
@@ -94,6 +96,8 @@ class XlsxParser(Parser):
             else:
                 sheet = book.worksheets[dialect.sheet - 1]
         except (KeyError, IndexError):
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             note = 'Excel document "%s" does not have a sheet "%s"'
             error = errors.FormatError(
                 note=note % (self.resource.fullpath, dialect.sheet)
@@ -135,6 +139,8 @@ class XlsxParser(Parser):
                             hasher.update(chunk)
                         self.resource.stats["hash"] = hasher.hexdigest()
                 except Exception as exception:
+                    if os.environ.get("DEBUG", 0) == "1":
+                        raise
                     error = errors.HashingError(note=str(exception))
                     raise FrictionlessException(error)
 

--- a/frictionless/plugins/inline/parser.py
+++ b/frictionless/plugins/inline/parser.py
@@ -44,6 +44,8 @@ class InlineParser(Parser):
         try:
             item = next(data)
         except StopIteration:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             yield from []
             return
 
@@ -94,3 +96,6 @@ class InlineParser(Parser):
                     data.append(row.field_names)
                 data.append(item)
         target.data = data
+
+
+import os

--- a/frictionless/plugins/json/parser/json.py
+++ b/frictionless/plugins/json/parser/json.py
@@ -42,6 +42,8 @@ class JsonParser(Parser):
             try:
                 yield next(parser.list_stream)
             except StopIteration:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 note = f'cannot extract JSON tabular data from "{self.resource.fullpath}"'
                 raise FrictionlessException(errors.SourceError(note=note))
             if parser.resource.dialect.keyed:
@@ -66,3 +68,6 @@ class JsonParser(Parser):
             json.dump(data, file, indent=2)
         loader = system.create_loader(target)
         loader.write_byte_stream(file.name)
+
+
+import os

--- a/frictionless/plugins/multipart/loader.py
+++ b/frictionless/plugins/multipart/loader.py
@@ -96,6 +96,8 @@ class MultipartByteStream:
             try:
                 res += next(self.__line_stream)
             except StopIteration:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 break
             if len(res) > size:
                 break
@@ -108,3 +110,6 @@ class MultipartByteStream:
                     if not self.__headless and number > 1 and line_number == 1:
                         continue
                     yield line
+
+
+import os

--- a/frictionless/plugins/ods/parser.py
+++ b/frictionless/plugins/ods/parser.py
@@ -45,6 +45,8 @@ class OdsParser(Parser):
             else:
                 sheet = book.sheets[dialect.sheet - 1]
         except (KeyError, IndexError):
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             note = 'OpenOffice document "%s" does not have a sheet "%s"'
             note = note % (self.resource.fullpath, dialect.sheet)
             raise FrictionlessException(errors.FormatError(note=note))
@@ -97,3 +99,6 @@ class OdsParser(Parser):
             book.save()
         loader = system.create_loader(target)
         loader.write_byte_stream(file.name)
+
+
+import os

--- a/frictionless/plugins/stream/loader.py
+++ b/frictionless/plugins/stream/loader.py
@@ -24,6 +24,8 @@ class StreamLoader(Loader):
             try:
                 byte_stream = open(byte_stream.name, "rb")
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 note = f"cannot open a stream in the byte mode: {byte_stream}"
                 raise FrictionlessException(errors.SchemeError(note=note))
         byte_stream = ReusableByteStream(byte_stream)
@@ -50,6 +52,8 @@ class ReusableByteStream:
             try:
                 self.__byte_stream = open(self.__byte_stream.name, "rb")
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 note = "cannot re-open a byte stream: {self.__byte_stream}"
                 raise FrictionlessException(errors.SchemeError(note=note))
         return self.__byte_stream.read(size)

--- a/frictionless/program/describe.py
+++ b/frictionless/program/describe.py
@@ -144,6 +144,8 @@ def program_describe(
     try:
         metadata = describe(source, **options)
     except Exception as exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         typer.secho(str(exception), err=True, fg=typer.colors.RED, bold=True)
         raise typer.Exit(1)
 
@@ -171,3 +173,6 @@ def program_describe(
     typer.secho("")
     typer.secho(metadata.to_yaml().strip())
     typer.secho("")
+
+
+import os

--- a/frictionless/program/extract.py
+++ b/frictionless/program/extract.py
@@ -171,6 +171,8 @@ def program_extract(
         process = (lambda row: row.to_dict(json=True)) if json or yaml else None
         data = extract(source, process=process, **options)
     except Exception as exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         typer.secho(str(exception), err=True, fg=typer.colors.RED, bold=True)
         raise typer.Exit(1)
 
@@ -215,3 +217,6 @@ def program_extract(
         typer.secho(str(petl.util.vis.lookall(subdata, vrepr=str, style="simple")))
         if number < len(normdata):
             typer.secho("")
+
+
+import os

--- a/frictionless/program/transform.py
+++ b/frictionless/program/transform.py
@@ -43,6 +43,8 @@ def program_transform(
                 for error in group:
                     raise FrictionlessException(error)
     except Exception as exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         typer.secho(str(exception), err=True, fg=typer.colors.RED, bold=True)
         raise typer.Exit(1)
 
@@ -65,3 +67,6 @@ def program_transform(
     typer.secho(f"# {'-'*len(prefix)}", bold=True)
     typer.secho(f"# {prefix}: {source}", bold=True)
     typer.secho(f"# {'-'*len(prefix)}", bold=True)
+
+
+import os

--- a/frictionless/program/validate.py
+++ b/frictionless/program/validate.py
@@ -197,6 +197,8 @@ def program_validate(
     try:
         report = validate(source, **options)
     except Exception as exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         typer.secho(str(exception), err=True, fg=typer.colors.RED, bold=True)
         raise typer.Exit(1)
 
@@ -273,3 +275,6 @@ def program_validate(
 
     # Return retcode
     raise typer.Exit(code=int(not report.valid))
+
+
+import os

--- a/frictionless/report.py
+++ b/frictionless/report.py
@@ -156,6 +156,8 @@ class Report(Metadata):
             try:
                 return validate(*args, **kwargs)
             except Exception as exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 error = TaskError(note=str(exception))
                 if isinstance(exception, FrictionlessException):
                     error = exception.error
@@ -341,3 +343,6 @@ class ReportTask(Metadata):
         if not isinstance(resource, Resource):
             resource = Resource(resource)
             dict.__setitem__(self, "resource", resource)
+
+
+import os

--- a/frictionless/resource/actions/transform.py
+++ b/frictionless/resource/actions/transform.py
@@ -45,6 +45,8 @@ def transform(resource: "Resource", *, steps):
         try:
             step.transform_resource(resource)
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             error = errors.StepError(note=f'"{get_name(step)}" raises "{exception}"')
             raise FrictionlessException(error) from exception
 
@@ -83,8 +85,13 @@ class DataWithErrorHandling:
         try:
             yield from self.data() if callable(self.data) else self.data
         except Exception as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             if isinstance(exception, FrictionlessException):
                 if exception.error.code == "step-error":
                     raise
             error = errors.StepError(note=f'"{get_name(self.step)}" raises "{exception}"')
             raise FrictionlessException(error) from exception
+
+
+import os

--- a/frictionless/resource/actions/validate.py
+++ b/frictionless/resource/actions/validate.py
@@ -53,6 +53,8 @@ def validate(
         stats = {key: val for key, val in resource.stats.items() if val}
         original_resource = resource.to_copy()
     except FrictionlessException as exception:
+        if os.environ.get("DEBUG", 0) == "1":
+            raise
         resource = None
         errors.append(exception.error)
 
@@ -61,6 +63,8 @@ def validate(
         try:
             resource.open()
         except FrictionlessException as exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             errors.append(exception.error)
             resource.close()
 
@@ -200,3 +204,6 @@ class ManagedErrors(list):
             if Error.code in self.__scope:
                 continue
             self.__scope.append(Error.code)
+
+
+import os

--- a/frictionless/resource/resource.py
+++ b/frictionless/resource/resource.py
@@ -649,6 +649,8 @@ class Resource(Metadata):
             system.create_parser(self)
             return True
         except Exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             return False
 
     @property
@@ -796,6 +798,8 @@ class Resource(Metadata):
 
         # Error
         except Exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             self.close()
             raise
 

--- a/frictionless/row.py
+++ b/frictionless/row.py
@@ -67,6 +67,8 @@ class Row(dict):
         try:
             field, field_number, field_position = self.__field_info["mapping"][key]
         except KeyError:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             raise KeyError(f"Row does not have a field {key}")
         if len(self.__cells) < field_number:
             self.__cells.extend([None] * (field_number - len(self.__cells)))
@@ -286,6 +288,8 @@ class Row(dict):
             try:
                 field, field_number, field_position = self.__field_info["mapping"][key]
             except KeyError:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 raise KeyError(f"Row does not have a field {key}")
             cell = cells[field_number - 1] if len(cells) >= field_number else None
             iterator = zip([(field, field_number, field_position)], [cell])
@@ -399,3 +403,6 @@ class Row(dict):
 
         # Set processed
         self.__processed = True
+
+
+import os

--- a/frictionless/types/array.py
+++ b/frictionless/types/array.py
@@ -28,6 +28,8 @@ class ArrayType(Type):
                 try:
                     cell = json.loads(cell)
                 except Exception:
+                    if os.environ.get("DEBUG", 0) == "1":
+                        raise
                     return None
                 if not isinstance(cell, list):
                     return None
@@ -41,3 +43,6 @@ class ArrayType(Type):
 
     def write_cell(self, cell):
         return json.dumps(cell)
+
+
+import os

--- a/frictionless/types/date.py
+++ b/frictionless/types/date.py
@@ -47,6 +47,8 @@ class DateType(Type):
             else:
                 cell = datetime.strptime(cell, self.field.format).date()
         except Exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             return None
 
         return cell
@@ -56,3 +58,6 @@ class DateType(Type):
     def write_cell(self, cell):
         format = self.field.get("format", settings.DEFAULT_DATE_PATTERN)
         return cell.strftime(format)
+
+
+import os

--- a/frictionless/types/datetime.py
+++ b/frictionless/types/datetime.py
@@ -39,6 +39,8 @@ class DatetimeType(Type):
                 else:
                     cell = datetime.strptime(cell, self.field.format)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         return cell
 
@@ -49,3 +51,6 @@ class DatetimeType(Type):
         cell = cell.strftime(format)
         cell = cell.replace("+0000", "Z")
         return cell
+
+
+import os

--- a/frictionless/types/duration.py
+++ b/frictionless/types/duration.py
@@ -28,6 +28,8 @@ class DurationType(Type):
             try:
                 cell = isodate.parse_duration(cell)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         return cell
 
@@ -35,3 +37,6 @@ class DurationType(Type):
 
     def write_cell(self, cell):
         return isodate.duration_isoformat(cell)
+
+
+import os

--- a/frictionless/types/geojson.py
+++ b/frictionless/types/geojson.py
@@ -27,6 +27,8 @@ class GeojsonType(Type):
             try:
                 cell = json.loads(cell)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         if not isinstance(cell, dict):
             return None
@@ -34,6 +36,8 @@ class GeojsonType(Type):
             try:
                 validators[self.field.format].validate(cell)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         return cell
 
@@ -50,3 +54,4 @@ validators = {
     "default": validator_for(settings.GEOJSON_PROFILE)(settings.GEOJSON_PROFILE),
     "topojson": validator_for(settings.TOPOJSON_PROFILE)(settings.TOPOJSON_PROFILE),
 }
+import os

--- a/frictionless/types/geopoint.py
+++ b/frictionless/types/geopoint.py
@@ -42,6 +42,8 @@ class GeopointType(Type):
                     lat = cell["lat"]
                 cell = geopoint(Decimal(lon), Decimal(lat))
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
 
         # Validate
@@ -52,6 +54,8 @@ class GeopointType(Type):
             if cell.lat > 90 or cell.lat < -90:
                 return None
         except Exception:
+            if os.environ.get("DEBUG", 0) == "1":
+                raise
             return None
 
         return cell
@@ -70,3 +74,4 @@ class GeopointType(Type):
 
 geopoint = namedtuple("geopoint", ["lon", "lat"])
 geopoint.__repr__ = lambda self: str([float(self[0]), float(self[1])])  # type: ignore
+import os

--- a/frictionless/types/integer.py
+++ b/frictionless/types/integer.py
@@ -31,6 +31,8 @@ class IntegerType(Type):
             try:
                 return int(cell)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         elif cell is True or cell is False:
             return None
@@ -51,3 +53,6 @@ class IntegerType(Type):
 
     def write_cell(self, cell):
         return str(cell)
+
+
+import os

--- a/frictionless/types/number.py
+++ b/frictionless/types/number.py
@@ -36,6 +36,8 @@ class NumberType(Type):
             try:
                 return Primary(cell)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         elif isinstance(cell, Primary):
             return cell
@@ -79,3 +81,6 @@ class NumberType(Type):
         if "decimalChar" in self.field:
             cell = cell.replace(".", self.field.decimal_char)
         return cell
+
+
+import os

--- a/frictionless/types/object.py
+++ b/frictionless/types/object.py
@@ -29,6 +29,8 @@ class ObjectType(Type):
             try:
                 cell = json.loads(cell)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
             if not isinstance(cell, dict):
                 return None
@@ -38,3 +40,6 @@ class ObjectType(Type):
 
     def write_cell(self, cell):
         return json.dumps(cell)
+
+
+import os

--- a/frictionless/types/string.py
+++ b/frictionless/types/string.py
@@ -35,6 +35,8 @@ class StringType(Type):
             try:
                 uri_validator.validate(uri)
             except rfc3986.exceptions.ValidationError:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         elif self.field.format == "email":
             if not validators.email(cell):
@@ -46,6 +48,8 @@ class StringType(Type):
             try:
                 base64.b64decode(cell)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         return cell
 
@@ -58,3 +62,4 @@ class StringType(Type):
 # Internal
 
 uri_validator = rfc3986.validators.Validator().require_presence_of("scheme")
+import os

--- a/frictionless/types/time.py
+++ b/frictionless/types/time.py
@@ -39,6 +39,8 @@ class TimeType(Type):
                 else:
                     cell = datetime.strptime(cell, self.field.format).timetz()
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         return cell
 
@@ -49,3 +51,6 @@ class TimeType(Type):
         cell = cell.strftime(format)
         cell = cell.replace("+0000", "Z")
         return cell
+
+
+import os

--- a/frictionless/types/year.py
+++ b/frictionless/types/year.py
@@ -30,6 +30,8 @@ class YearType(Type):
             try:
                 cell = int(cell)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         if cell < 0 or cell > 9999:
             return None
@@ -39,3 +41,6 @@ class YearType(Type):
 
     def write_cell(self, cell):
         return str(cell)
+
+
+import os

--- a/frictionless/types/yearmonth.py
+++ b/frictionless/types/yearmonth.py
@@ -36,6 +36,8 @@ class YearmonthType(Type):
                     return None
                 cell = yearmonth(year, month)
             except Exception:
+                if os.environ.get("DEBUG", 0) == "1":
+                    raise
                 return None
         else:
             return None
@@ -50,3 +52,4 @@ class YearmonthType(Type):
 # Internal
 
 yearmonth = namedtuple("yearmonth", ["year", "month"])
+import os


### PR DESCRIPTION
- fixes #840

Just a proof of concept to see how a catch all exception and raise immediately would work. I added to all "try ; except" blocks a check to see if an environment variable DEBUG was set to 1. In that case I would raise it instead of continue the normal program.

Example of the CLI running without setting the env variable:

```
(fric) ➜  frictionless-py git:(840-adds-debug-mode) ✗ frictionless validate  not-existing-file 
# -------
# invalid: not-existing-file (non-tabular)
# -------

===  =====  ============  ==========================================================================================================
row  field  code          message                                                                                                   
===  =====  ============  ==========================================================================================================
            scheme-error  The data source could not be successfully loaded: [Errno 2] No such file or directory: 'not-existing-file'
===  =====  ============  ==========================================================================================================
```

And with DEBUG=1:

```
(fric) ➜  frictionless-py git:(840-adds-debug-mode) ✗ DEBUG=1 frictionless validate  not-existing-file
Traceback (most recent call last):
  File "/home/aivuk/fric/bin/frictionless", line 33, in <module>
    sys.exit(load_entry_point('frictionless', 'console_scripts', 'frictionless')())
  File "/home/aivuk/fric/lib/python3.10/site-packages/typer-0.4.1-py3.10.egg/typer/main.py", line 214, in __call__
    return get_command(self)(*args, **kwargs)
  File "/home/aivuk/fric/lib/python3.10/site-packages/click-8.1.3-py3.10.egg/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/aivuk/fric/lib/python3.10/site-packages/click-8.1.3-py3.10.egg/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/aivuk/fric/lib/python3.10/site-packages/click-8.1.3-py3.10.egg/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/aivuk/fric/lib/python3.10/site-packages/click-8.1.3-py3.10.egg/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/aivuk/fric/lib/python3.10/site-packages/click-8.1.3-py3.10.egg/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/aivuk/fric/lib/python3.10/site-packages/typer-0.4.1-py3.10.egg/typer/main.py", line 500, in wrapper
    return callback(**use_params)  # type: ignore
  File "/home/aivuk/frictionless/frictionless-py/frictionless/program/validate.py", line 198, in program_validate
    report = validate(source, **options)
  File "/home/aivuk/frictionless/frictionless-py/frictionless/report.py", line 157, in wrapper
    return validate(*args, **kwargs)
  File "/home/aivuk/frictionless/frictionless-py/frictionless/actions/validate.py", line 50, in validate
    return validate(source, deprecate=False, **options)
  File "/home/aivuk/frictionless/frictionless-py/frictionless/report.py", line 157, in wrapper
    return validate(*args, **kwargs)
  File "/home/aivuk/frictionless/frictionless-py/frictionless/actions/validate.py", line 221, in validate_resource
    stats = {key: val for key, val in resource.stats.items() if val}
  File "/home/aivuk/frictionless/frictionless-py/frictionless/helpers.py", line 537, in __get__
    val = self.func(instance)
  File "/home/aivuk/frictionless/frictionless-py/frictionless/resource/resource.py", line 520, in stats
    if self.tabular:
  File "/home/aivuk/frictionless/frictionless-py/frictionless/helpers.py", line 537, in __get__
    val = self.func(instance)
  File "/home/aivuk/frictionless/frictionless-py/frictionless/resource/resource.py", line 649, in tabular
    system.create_parser(self)
  File "/home/aivuk/frictionless/frictionless-py/frictionless/system.py", line 214, in create_parser
    raise FrictionlessException(errors.FormatError(note=note))
frictionless.exception.FrictionlessException: [format-error] The data source could not be successfully parsed: cannot create parser "". Try installing "frictionless-"

```

To add the DEBUG check I used sed in all files with an exception block:
`
find frictionless -name '*py' -exec sed -i 's/^\(\([[:space:]]*\)except .*$\)/\1\n\2    if os.environ.get("DEBUG", 0) == "1":\n\2        raise/g' {} \;`

@roll is that what you had in mind? @shashigharti thoughts?

For me as developer, having the complete stack trace is helpful but as you can see in the example above, without the DEBUG set it's easier to understand the error with the FD standard message, but I believe that in other cases the stack trace will be more helpful, specially if we want to know exactly where to add a breakpoint to debug.