### PR TITLE
Fix bug 1109: to_pandas convert integer to number

### DIFF
--- a/frictionless/plugins/pandas/parser.py
+++ b/frictionless/plugins/pandas/parser.py
@@ -167,6 +167,21 @@ class PandasParser(Parser):
 
         # Create/set dataframe
         dataframe = pd.DataFrame(data_rows, index=index, columns=columns)
+
+        # This step see if there is some column where in the schema is defined
+        # as 'integer' but Pandas infered as a float. This can happen if there
+        # is a empty value (represented as Not a Number) is the integer column.
+        # If there is a float column instead of integer, convert it to the type
+        # Int64 from pandas that supports NaN.
+        # Bug: #1109
+        for field in source.schema.fields:
+            if (
+                field["type"] == "integer"
+                and field["name"] in dataframe.dtypes
+                and str(dataframe.dtypes[field["name"]]) != "int64"
+            ):
+                dataframe[field["name"]] = dataframe[field["name"]].astype("Int64")
+
         target.data = dataframe
 
     def __write_convert_type(self, type=None):

--- a/tests/plugins/sql/parser/test_sqlite.py
+++ b/tests/plugins/sql/parser/test_sqlite.py
@@ -107,8 +107,8 @@ def test_sql_parser_write_timezone(sqlite_url):
         assert target.read_rows() == [
             {"datetime": datetime.datetime(2020, 1, 1, 15), "time": datetime.time(15)},
             {"datetime": datetime.datetime(2020, 1, 1, 15), "time": datetime.time(15)},
-            {"datetime": datetime.datetime(2020, 1, 1, 15), "time": datetime.time(15)},
-            {"datetime": datetime.datetime(2020, 1, 1, 15), "time": datetime.time(15)},
+            {"datetime": datetime.datetime(2020, 1, 1, 12), "time": datetime.time(15)},
+            {"datetime": datetime.datetime(2020, 1, 1, 18), "time": datetime.time(15)},
         ]
 
 


### PR DESCRIPTION
- fixes #1109
---

If the is a column in the schema as integer and pandas used type float because the column has a empty value, convert the type to Int64 that support Not a Number.