### PR TITLE
Fixes to_pandas conversion without types

### DIFF
--- a/frictionless/plugins/pandas/parser.py
+++ b/frictionless/plugins/pandas/parser.py
@@ -176,11 +176,11 @@ class PandasParser(Parser):
         # Bug: #1109
         for field in source.schema.fields:
             if (
-                field["type"] == "integer"
-                and field["name"] in dataframe.columns
-                and str(dataframe.dtypes[field["name"]]) != "int64"
+                field.type == "integer"
+                and field.name in dataframe.columns
+                and str(dataframe.dtypes[field.name]) != "int64"
             ):
-                dataframe[field["name"]] = dataframe[field["name"]].astype("Int64")
+                dataframe[field.name] = dataframe[field.name].astype("Int64")
 
         target.data = dataframe
 

--- a/tests/plugins/pandas/test_parser.py
+++ b/tests/plugins/pandas/test_parser.py
@@ -74,6 +74,42 @@ def test_pandas_nan_in_integer_csv_column():
     assert all(df.dtypes.values == pd.array([pd.Int64Dtype(), float, object]))
 
 
+def test_pandas_nan_with_field_type_information_1143():
+    descriptor = {
+        "dialect": {"delimiter": ","},
+        "name": "issue-1109",
+        "path": "data/issue-1109.csv",
+        "schema": {
+            "fields": [
+                {"name": "int", "type": "integer"},
+                {"name": "number", "type": "number"},
+                {"name": "string", "type": "string"},
+            ]
+        },
+    }
+    res = Resource(descriptor)
+    df = res.to_pandas()
+    assert all(df.dtypes.values == pd.array([pd.Int64Dtype(), float, object]))
+
+
+def test_pandas_nan_without_field_type_information_1143():
+    descriptor = {
+        "dialect": {"delimiter": ","},
+        "name": "issue-1109",
+        "path": "data/issue-1109.csv",
+        "schema": {
+            "fields": [
+                {"name": "int"},
+                {"name": "number"},
+                {"name": "string"},
+            ]
+        },
+    }
+    res = Resource(descriptor)
+    df = res.to_pandas()
+    assert all(df.dtypes.values == pd.array([object, object, object]))
+
+
 def test_pandas_parser_write_types():
     source = Package("data/storage/types.json").get_resource("types")
     target = source.write(format="pandas")


### PR DESCRIPTION
Replaced field type check using Frictionless Field property instead of dict keys
Added tests

- fixes #1143

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
