### PR TITLE
Fix 1155: fix field_filter field name order in schema + tollerate field name which does not exist

### DIFF
--- a/frictionless/steps/field/field_filter.py
+++ b/frictionless/steps/field/field_filter.py
@@ -20,9 +20,8 @@ class field_filter(Step):
     def transform_resource(self, resource):
         table = resource.to_petl()
         names = self.get("names")
-        for name in resource.schema.field_names:
-            if name not in names:
-                resource.schema.remove_field(name)
+        schema_fields_dict = {dct["name"]: dct for dct in resource.schema.fields}
+        resource.schema.fields = [schema_fields_dict[name] for name in names]
         resource.data = table.cut(*names)
 
     # Metadata

--- a/frictionless/steps/field/field_filter.py
+++ b/frictionless/steps/field/field_filter.py
@@ -21,8 +21,12 @@ class field_filter(Step):
         table = resource.to_petl()
         names = self.get("names")
         schema_fields_dict = {dct["name"]: dct for dct in resource.schema.fields}
-        resource.schema.fields = [schema_fields_dict[name] for name in names]
-        resource.data = table.cut(*names)
+        new_schema_fields = [
+            schema_fields_dict[name] for name in names if name in schema_fields_dict
+        ]
+        resource.schema.fields = new_schema_fields
+        new_names = [dct["name"] for dct in new_schema_fields]
+        resource.data = table.cut(*new_names)
 
     # Metadata
 

--- a/frictionless/steps/field/field_filter.py
+++ b/frictionless/steps/field/field_filter.py
@@ -19,7 +19,7 @@ class field_filter(Step):
 
     def transform_resource(self, resource):
         table = resource.to_petl()
-        names = self.get("names")
+        names = self.get("names", [])
         schema_fields_dict = {dct["name"]: dct for dct in resource.schema.fields}
         new_schema_fields = [
             schema_fields_dict[name] for name in names if name in schema_fields_dict

--- a/tests/steps/field/test_field_filter.py
+++ b/tests/steps/field/test_field_filter.py
@@ -1,4 +1,8 @@
+import pytest
+
+
 from frictionless import Resource, transform, steps
+from frictionless.exception import FrictionlessException
 
 
 # General
@@ -43,4 +47,24 @@ def test_step_field_filter_changed_field_order():
         {"name": "germany", "id": 1},
         {"name": "france", "id": 2},
         {"name": "spain", "id": 3},
+    ]
+
+
+def test_step_field_filter_missing_name():
+    source = Resource(path="data/transform.csv")
+    target = transform(
+        source,
+        steps=[
+            steps.field_filter(names=["name", "nonexistent"]),
+        ],
+    )
+    assert target.schema == {
+        "fields": [
+            {"name": "name", "type": "string"},
+        ]
+    }
+    assert target.read_rows() == [
+        {"name": "germany"},
+        {"name": "france"},
+        {"name": "spain"},
     ]

--- a/tests/steps/field/test_field_filter.py
+++ b/tests/steps/field/test_field_filter.py
@@ -23,3 +23,24 @@ def test_step_field_filter():
         {"id": 2, "name": "france"},
         {"id": 3, "name": "spain"},
     ]
+
+
+def test_step_field_filter_changed_field_order():
+    source = Resource(path="data/transform.csv")
+    target = transform(
+        source,
+        steps=[
+            steps.field_filter(names=["name", "id"]),
+        ],
+    )
+    assert target.schema == {
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "id", "type": "integer"},
+        ]
+    }
+    assert target.read_rows() == [
+        {"name": "germany", "id": 1},
+        {"name": "france", "id": 2},
+        {"name": "spain", "id": 3},
+    ]

--- a/tests/steps/field/test_field_filter.py
+++ b/tests/steps/field/test_field_filter.py
@@ -102,6 +102,17 @@ from frictionless import Resource, transform, steps
                 {},
             ],
         },
+        {
+            "test_id": "all_names_not_existing",
+            "csv_path": "data/transform.csv",
+            "names": ["extra_id", "extra_name", "extra_population"],
+            "expected_schema": {"fields": []},
+            "expected_rows": [
+                {},
+                {},
+                {},
+            ],
+        },
     ],
     ids=lambda scenario: scenario["test_id"],
 )

--- a/tests/steps/field/test_field_filter.py
+++ b/tests/steps/field/test_field_filter.py
@@ -2,69 +2,121 @@ import pytest
 
 
 from frictionless import Resource, transform, steps
-from frictionless.exception import FrictionlessException
 
 
 # General
 
 
-def test_step_field_filter():
-    source = Resource(path="data/transform.csv")
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        {
+            "test_id": "idem",
+            "csv_path": "data/transform.csv",
+            "names": ["id", "name", "population"],
+            "expected_schema": {
+                "fields": [
+                    {"name": "id", "type": "integer"},
+                    {"name": "name", "type": "string"},
+                    {"name": "population", "type": "integer"},
+                ]
+            },
+            "expected_rows": [
+                {"id": 1, "name": "germany", "population": 83},
+                {"id": 2, "name": "france", "population": 66},
+                {"id": 3, "name": "spain", "population": 47},
+            ],
+        },
+        {
+            "test_id": "reverse_field_order",
+            "csv_path": "data/transform.csv",
+            "names": ["population", "name", "id"],
+            "expected_schema": {
+                "fields": [
+                    {"name": "population", "type": "integer"},
+                    {"name": "name", "type": "string"},
+                    {"name": "id", "type": "integer"},
+                ]
+            },
+            "expected_rows": [
+                {"population": 83, "name": "germany", "id": 1},
+                {"population": 66, "name": "france", "id": 2},
+                {"population": 47, "name": "spain", "id": 3},
+            ],
+        },
+        {
+            "test_id": "remove_last_column",
+            "csv_path": "data/transform.csv",
+            "names": ["id", "name"],
+            "expected_schema": {
+                "fields": [
+                    {"name": "id", "type": "integer"},
+                    {"name": "name", "type": "string"},
+                ]
+            },
+            "expected_rows": [
+                {"id": 1, "name": "germany"},
+                {"id": 2, "name": "france"},
+                {"id": 3, "name": "spain"},
+            ],
+        },
+        {
+            "test_id": "changed_field_order",
+            "csv_path": "data/transform.csv",
+            "names": ["name", "id"],
+            "expected_schema": {
+                "fields": [
+                    {"name": "name", "type": "string"},
+                    {"name": "id", "type": "integer"},
+                ]
+            },
+            "expected_rows": [
+                {"name": "germany", "id": 1},
+                {"name": "france", "id": 2},
+                {"name": "spain", "id": 3},
+            ],
+        },
+        {
+            "test_id": "missing_name",
+            "csv_path": "data/transform.csv",
+            "names": ["name", "nonexistent"],
+            "expected_schema": {
+                "fields": [
+                    {"name": "name", "type": "string"},
+                ]
+            },
+            "expected_rows": [
+                {"name": "germany"},
+                {"name": "france"},
+                {"name": "spain"},
+            ],
+        },
+        {
+            "test_id": "no_fields",
+            "csv_path": "data/transform.csv",
+            "names": [],
+            "expected_schema": {"fields": []},
+            "expected_rows": [
+                {},
+                {},
+                {},
+            ],
+        },
+    ],
+    ids=lambda scenario: scenario["test_id"],
+)
+def test_step_field_filter(scenario):
+    csv_path = scenario["csv_path"]
+    names = scenario["names"]
+    expected_schema = scenario["expected_schema"]
+    expected_rows = scenario["expected_rows"]
+
+    source = Resource(path=csv_path)
     target = transform(
         source,
         steps=[
-            steps.field_filter(names=["id", "name"]),
+            steps.field_filter(names=names),
         ],
     )
-    assert target.schema == {
-        "fields": [
-            {"name": "id", "type": "integer"},
-            {"name": "name", "type": "string"},
-        ]
-    }
-    assert target.read_rows() == [
-        {"id": 1, "name": "germany"},
-        {"id": 2, "name": "france"},
-        {"id": 3, "name": "spain"},
-    ]
-
-
-def test_step_field_filter_changed_field_order():
-    source = Resource(path="data/transform.csv")
-    target = transform(
-        source,
-        steps=[
-            steps.field_filter(names=["name", "id"]),
-        ],
-    )
-    assert target.schema == {
-        "fields": [
-            {"name": "name", "type": "string"},
-            {"name": "id", "type": "integer"},
-        ]
-    }
-    assert target.read_rows() == [
-        {"name": "germany", "id": 1},
-        {"name": "france", "id": 2},
-        {"name": "spain", "id": 3},
-    ]
-
-
-def test_step_field_filter_missing_name():
-    source = Resource(path="data/transform.csv")
-    target = transform(
-        source,
-        steps=[
-            steps.field_filter(names=["name", "nonexistent"]),
-        ],
-    )
-    assert target.schema == {
-        "fields": [
-            {"name": "name", "type": "string"},
-        ]
-    }
-    assert target.read_rows() == [
-        {"name": "germany"},
-        {"name": "france"},
-        {"name": "spain"},
-    ]
+    assert target.schema == expected_schema
+    assert target.read_rows() == expected_rows


### PR DESCRIPTION
- fixes #1155

It fixes field_filter - resulting rows have names and field names properly aligned (order of fields in schema fixed)

The latest commit allows to use field names which are missing.
