### PR TITLE
Fixing typo

### DIFF
--- a/docs/guides/validation-guide.md
+++ b/docs/guides/validation-guide.md
@@ -1262,7 +1262,7 @@ pprint(report.flatten(["rowPosition", "fieldPosition", "code"]))
 
 ## Limit Memory
 
-Frictionless is a streaming engine; usually it is possible to validate terrabytes of data with basically O(1) memory consumption. It means that memory usage doesn't depend on the size of your data making the validation infinitely scalable. For some validation, this is not the case because Frctionless needs to buffer some cells e.g. to check uniqueness. Here memory management can be handy.
+Frictionless is a streaming engine; usually it is possible to validate terabytes of data with basically O(1) memory consumption. It means that memory usage doesn't depend on the size of your data making the validation infinitely scalable. For some validation, this is not the case because Frctionless needs to buffer some cells e.g. to check uniqueness. Here memory management can be handy.
 
 The default memory limit is 1000MB. You can adjust this based on your exact use case. For example, if you're running Frictionless as an API server you might reduce the memory usage. If a validation hits the limit it will not raise a failure - it will return a report with a task error:
 


### PR DESCRIPTION
Fixing typo `terrabytes` to `terabytes`
