### PR TITLE
Replace old discord links for slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Release](https://img.shields.io/pypi/v/frictionless.svg)](https://pypi.python.org/pypi/frictionless)
 [![Citation](https://zenodo.org/badge/28409905.svg)](https://zenodo.org/badge/latestdoi/28409905)
 [![Codebase](https://img.shields.io/badge/codebase-github-brightgreen)](https://github.com/frictionlessdata/frictionless-py)
-[![Support](https://img.shields.io/badge/support-discord-brightgreen)](https://discordapp.com/invite/Sewv6av)
+[![Support](https://img.shields.io/badge/support-slack-brightgreen)](https://join.slack.com/t/frictionlessdata/shared_invite/zt-17kpbffnm-tRfDW_wJgOw8tJVLvZTrBg)
 
 Data management framework for Python that provides functionality to describe, extract, validate, and transform tabular data (DEVT Framework). It supports a great deal of data schemes and formats, as well as provides popular platforms integrations. The framework is powered by the lightweight yet comprehensive [Frictionless Standards](https://specs.frictionlessdata.io/).
 

--- a/livemark.yaml
+++ b/livemark.yaml
@@ -23,7 +23,7 @@ links:
     - name: Frictionless
       path: https://frictionlessdata.io
     - name: Support
-      path: https://discord.com/channels/695635777199145130/695635777199145133
+      path: https://join.slack.com/t/frictionlessdata/shared_invite/zt-17kpbffnm-tRfDW_wJgOw8tJVLvZTrBg
 pages:
   items:
     - path: index


### PR DESCRIPTION
Removes deprecated discord link for slack. I used the slack invite link included here: https://github.com/frictionlessdata/frictionless-py/blob/main/blog/2022/08-22-frictionless-framework-v5.md

- fixes https://github.com/frictionlessdata/project/issues/716