### PR TITLE
Use executemany for db writes and fix #1196 sqlite too many variables

### DIFF
--- a/frictionless/formats/sql/storage.py
+++ b/frictionless/formats/sql/storage.py
@@ -325,10 +325,12 @@ class SqlStorage(Storage):
                                 row[field.name] = dt.time()
                 buffer.append(row)
                 if len(buffer) > buffer_size:
-                    self.__connection.execute(sql_table.insert().values(buffer))
+                    # sqlalchemy conn.execute(sql_table.insert(), buffer)
+                    # syntax applies executemany DB API invocation.
+                    self.__connection.execute(sql_table.insert(), buffer)
                     buffer = []
             if len(buffer):
-                self.__connection.execute(sql_table.insert().values(buffer))
+                self.__connection.execute(sql_table.insert(), buffer)
 
     def __write_convert_type(self, type=None):
         sa = platform.sqlalchemy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,18 +71,18 @@ def sqlite_max_variable_number():
     #
     # Default value for stock SQLite >= 3.32.0
     # (https://www.sqlite.org/limits.html#max_variable_number): 32766
-    # 
+    #
     # Note that distributions *do* customize this e.g. Ubuntu 20.04:
     # MAX_VARIABLE_NUMBER=250000
-    conn = sqlite3.connect(':memory:')
+    conn = sqlite3.connect(":memory:")
     try:
         with conn:
-            result = conn.execute('pragma compile_options;').fetchall()
+            result = conn.execute("pragma compile_options;").fetchall()
     finally:
         conn.close()
     for item in result:
-        if item[0].startswith('MAX_VARIABLE_NUMBER='):
-            return int(item[0].split('=')[-1])
+        if item[0].startswith("MAX_VARIABLE_NUMBER="):
+            return int(item[0].split("=")[-1])
     return 32766
 
 

--- a/tests/formats/sql/storage/test_sqlite.py
+++ b/tests/formats/sql/storage/test_sqlite.py
@@ -285,10 +285,7 @@ def test_sql_storage_dialect_basepath_issue_964(sqlite_url):
         ]
 
 
-def test_sql_storage_max_parameters_issue_1196(
-        sqlite_url,
-        sqlite_max_variable_number
-    ):
+def test_sql_storage_max_parameters_issue_1196(sqlite_url, sqlite_max_variable_number):
     # SQLite applies limits for the max. number of characters in prepared
     # parameterized SQL statements, see https://www.sqlite.org/limits.html.
 
@@ -296,20 +293,23 @@ def test_sql_storage_max_parameters_issue_1196(
     # restrictions.
     buffer_size = 1000  # see formats/sql/storage.py
     number_of_rows = 10 * buffer_size
-    number_of_fields = divmod( sqlite_max_variable_number, buffer_size)[0] + 1
+    number_of_fields = divmod(sqlite_max_variable_number, buffer_size)[0] + 1
     assert number_of_fields * buffer_size > sqlite_max_variable_number
 
     # Create in-memory string csv test data.
-    data = '\n'.join([
-        ','.join(f'header{i}' for i in range(number_of_fields)),
-        '\n'.join(
-            ','.join(f'row{r}_col{c}' for c in range(number_of_fields))
-            for r in range(number_of_rows)
-            )
-        ]).encode('ascii')
+    data = "\n".join(
+        [
+            ",".join(f"header{i}" for i in range(number_of_fields)),
+            "\n".join(
+                ",".join(f"row{r}_col{c}" for c in range(number_of_fields))
+                for r in range(number_of_rows)
+            ),
+        ]
+    ).encode("ascii")
 
     # Write to the SQLite db. This must not raise an exception i.e. test is
     # successful if it runs without error.
-    with Resource(data, format='csv') as resource:
-        resource.write(sqlite_url,
-            control=formats.SqlControl(table='test_max_param_table'))
+    with Resource(data, format="csv") as resource:
+        resource.write(
+            sqlite_url, control=formats.SqlControl(table="test_max_param_table")
+        )


### PR DESCRIPTION
This PR
- adds a test for and fixes #1196
- improves performance according to timeit-based benchmarking, for SQLite, 
  PostgreSQL (psycopg) and MySQL (pymysql) 
  (see https://github.com/hjoukl/bench-sqlalchemy-executemany)

`make lint` & `make test`