### PR TITLE
Fixed bug in table-write step while using foreign key

### DIFF
--- a/data/package-with-pipeline-multiple-tables-to-write.json
+++ b/data/package-with-pipeline-multiple-tables-to-write.json
@@ -1,0 +1,151 @@
+{
+  "name": "petites_villes_de_demain",
+  "resources": [
+    {
+      "name": "commune",
+      "type": "table",
+      "path": "sqlite:///database.db",
+      "format": "sql",
+      "mediatype": "application/sql",
+      "dialect": {
+        "sql": {
+          "table": "commune"
+        }
+      },
+      "schema": {
+        "fields": [
+          {
+            "name": "insee_com",
+            "type": "string",
+            "constraints": {
+              "required": true
+            }
+          }
+        ],
+        "primaryKey": [
+          "insee_com"
+        ]
+      }
+    },
+    {
+      "name": "diffusion-zonages-zrr-cog2021",
+      "type": "table",
+      "path": "https://github.com/fdtester/temp-files/blob/main/diffusion-zonages-zrr-cog2021.xls?raw=true",
+      "scheme": "https",
+      "format": "xls",
+      "encoding": "utf-8",
+      "mediatype": "application/vnd.ms-excel",
+      "dialect": {
+        "headerRows": [
+          6
+        ]
+      },
+      "schema": {
+        "fields": [
+          {
+            "name": "CODGEO",
+            "type": "string"
+          },
+          {
+            "name": "LIBGEO",
+            "type": "string"
+          },
+          {
+            "name": "ZRR_SIMP",
+            "type": "string"
+          },
+          {
+            "name": "ZONAGE_ZRR",
+            "type": "string"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "fields": [
+              "CODGEO"
+            ],
+            "reference": {
+              "resource": "commune",
+              "fields": [
+                "insee_com"
+              ]
+            }
+          }
+        ]
+      },
+      "pipeline": {
+        "steps": [
+          {
+            "type": "table-write",
+            "path": "sqlite:///database.db",
+            "dialect": {
+              "sql": {
+                "table": "zrr"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "diffusion-zonages-zrr-cog2021-1",
+      "type": "table",
+      "path": "https://github.com/fdtester/temp-files/blob/main/diffusion-zonages-zrr-cog2021.xls?raw=true",
+      "scheme": "https",
+      "format": "xls",
+      "encoding": "utf-8",
+      "mediatype": "application/vnd.ms-excel",
+      "dialect": {
+        "headerRows": [
+          6
+        ]
+      },
+      "schema": {
+        "fields": [
+          {
+            "name": "CODGEO",
+            "type": "string"
+          },
+          {
+            "name": "LIBGEO",
+            "type": "string"
+          },
+          {
+            "name": "ZRR_SIMP",
+            "type": "string"
+          },
+          {
+            "name": "ZONAGE_ZRR",
+            "type": "string"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "fields": [
+              "CODGEO"
+            ],
+            "reference": {
+              "resource": "commune",
+              "fields": [
+                "insee_com"
+              ]
+            }
+          }
+        ]
+      },
+      "pipeline": {
+        "steps": [
+          {
+            "type": "table-write",
+            "path": "sqlite:///database.db",
+            "dialect": {
+              "sql": {
+                "table": "zrr1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/data/package-with-pipeline.json
+++ b/data/package-with-pipeline.json
@@ -1,0 +1,91 @@
+{
+  "name": "petites_villes_de_demain",
+  "resources": [
+    {
+      "name": "commune",
+      "type": "table",
+      "path": "sqlite:///database.db",
+      "format": "sql",
+      "mediatype": "application/sql",
+      "dialect": {
+        "sql": {
+          "table": "commune"
+        }
+      },
+      "schema": {
+        "fields": [
+          {
+            "name": "insee_com",
+            "type": "string",
+            "constraints": {
+              "required": true
+            }
+          }
+        ],
+        "primaryKey": [
+          "insee_com"
+        ]
+      }
+    },
+    {
+      "name": "diffusion-zonages-zrr-cog2021",
+      "type": "table",
+      "path": "https://github.com/fdtester/temp-files/blob/main/diffusion-zonages-zrr-cog2021.xls?raw=true",
+      "scheme": "https",
+      "format": "xls",
+      "encoding": "utf-8",
+      "mediatype": "application/vnd.ms-excel",
+      "dialect": {
+        "headerRows": [
+          6
+        ]
+      },
+      "schema": {
+        "fields": [
+          {
+            "name": "CODGEO",
+            "type": "string"
+          },
+          {
+            "name": "LIBGEO",
+            "type": "string"
+          },
+          {
+            "name": "ZRR_SIMP",
+            "type": "string"
+          },
+          {
+            "name": "ZONAGE_ZRR",
+            "type": "string"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "fields": [
+              "CODGEO"
+            ],
+            "reference": {
+              "resource": "commune",
+              "fields": [
+                "insee_com"
+              ]
+            }
+          }
+        ]
+      },
+      "pipeline": {
+        "steps": [
+          {
+            "type": "table-write",
+            "path": "sqlite:///database.db",
+            "dialect": {
+              "sql": {
+                "table": "zrr"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/frictionless/formats/sql/storage.py
+++ b/frictionless/formats/sql/storage.py
@@ -178,16 +178,22 @@ class SqlStorage(Storage):
     # Write
 
     def write_resource(self, resource, *, force=False):
-        package = Package(resources=[resource])
-        self.write_package(package, force=force)
+        package = resource.package or Package(resources=[resource])
+        ignore_resources = []
+        for resource in package.resources:
+            if resource.format == "sql" and not resource.data:
+                ignore_resources.append(resource.name)
+        self.write_package(package, ignore_resources, force=force)
 
-    def write_package(self, package, force=False):
+    def write_package(self, package, ignore_resources=None, force=False):
         existent_names = list(self)
 
         # Check existent
         delete_names = []
         for resource in package.resources:
             if resource.name in existent_names:
+                if ignore_resources and resource.name in ignore_resources:
+                    continue
                 if not force:
                     note = f'Resource "{resource.name}" already exists'
                     raise FrictionlessException(note)
@@ -200,6 +206,8 @@ class SqlStorage(Storage):
             sql_tables = []
             self.delete_package(delete_names)
             for resource in package.resources:
+                if ignore_resources and resource.name in ignore_resources:
+                    continue
                 if not resource.has_schema:
                     resource.infer()
                 sql_table = self.__write_convert_schema(resource)
@@ -209,6 +217,8 @@ class SqlStorage(Storage):
             # Write data
             existent_names = list(self)
             for name in existent_names:
+                if ignore_resources and name in ignore_resources:
+                    continue
                 if package.has_resource(name):
                     self.__write_convert_data(package.get_resource(name))
 

--- a/frictionless/steps/table/table_write.py
+++ b/frictionless/steps/table/table_write.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import attrs
 from ...pipeline import Step
 from ...resource import Resource
+from ...dialect import Dialect
 
 
 @attrs.define(kw_only=True)
@@ -20,7 +21,10 @@ class table_write(Step):
     # Transform
 
     def transform_resource(self, resource):
-        target = Resource(path=self.path, type="table")
+        dialect = None
+        if "dialect" in self.custom:
+            dialect = Dialect.from_descriptor(self.custom["dialect"])
+        target = Resource(path=self.path, type="table", dialect=dialect)
         resource.write(target)
 
     # Metadata

--- a/tests/resource/transform/test_general.py
+++ b/tests/resource/transform/test_general.py
@@ -1,4 +1,5 @@
 from frictionless import Resource, Pipeline, steps
+from frictionless import Package
 
 
 # General
@@ -48,3 +49,87 @@ def test_resource_transform_cell_set():
         {"id": 2, "name": "france", "population": 100},
         {"id": 3, "name": "spain", "population": 100},
     ]
+
+
+def test_resource_transform_table_creation_with_foreign_key(sqlite_url):
+    # write table
+    resource = Resource(
+        {
+            "name": "commune",
+            "schema": {
+                "fields": [{"name": "insee_com", "type": "string"}],
+                "primaryKey": ["insee_com"],
+            },
+            "data": [["insee_com"], ["01001"], ["01002"]],
+        }
+    )
+    source = Package(resources=[resource])
+    source.to_sql(sqlite_url)
+
+    # write table using pipeline step
+    package = Package("data/package-with-pipeline.json")
+    package.resources[0].path = sqlite_url
+    package.resources[1].pipeline.steps[0].path = sqlite_url  # type: ignore
+    for resource in package.resources:
+        if resource.pipeline:
+            resource.transform()
+
+    # read tables
+    target = Package.from_sql(sqlite_url)
+    assert target.get_resource("zrr").schema.to_descriptor() == {
+        "fields": [
+            {"name": "CODGEO", "type": "string"},
+            {"name": "LIBGEO", "type": "string"},
+            {"name": "ZRR_SIMP", "type": "string"},
+            {"name": "ZONAGE_ZRR", "type": "string"},
+        ],
+        "foreignKeys": [
+            {
+                "fields": ["CODGEO"],
+                "reference": {"resource": "commune", "fields": ["insee_com"]},
+            }
+        ],
+    }
+
+
+def test_resource_transform_multiple_table_creation_with_foreign_key(sqlite_url):
+    # write table
+    resource = Resource(
+        {
+            "name": "commune",
+            "schema": {
+                "fields": [{"name": "insee_com", "type": "string"}],
+                "primaryKey": ["insee_com"],
+            },
+            "data": [["insee_com"], ["01001"], ["01002"]],
+        }
+    )
+    source = Package(resources=[resource])
+    source.to_sql(sqlite_url)
+
+    # write table using pipeline step
+    package = Package("data/package-with-pipeline-multiple-tables-to-write.json")
+    package.resources[0].path = sqlite_url
+    package.resources[1].pipeline.steps[0].path = sqlite_url  # type: ignore
+    package.resources[2].pipeline.steps[0].path = sqlite_url  # type: ignore
+
+    for resource in package.resources:
+        if resource.pipeline:
+            resource.transform()
+
+    # read tables
+    target = Package.from_sql(sqlite_url)
+    assert target.get_resource("zrr").schema.to_descriptor() == {
+        "fields": [
+            {"name": "CODGEO", "type": "string"},
+            {"name": "LIBGEO", "type": "string"},
+            {"name": "ZRR_SIMP", "type": "string"},
+            {"name": "ZONAGE_ZRR", "type": "string"},
+        ],
+        "foreignKeys": [
+            {
+                "fields": ["CODGEO"],
+                "reference": {"resource": "commune", "fields": ["insee_com"]},
+            }
+        ],
+    }


### PR DESCRIPTION
- It fixes the bug while writing a table/resource using resource pipeline 'steps' 'table-write'. The bug appeared when the table being written had foreign key reference with another table resource.
-  There were bugs in two steps:
1. Please provide "dialect.sql.table" for writing
2. Error in __prepare_lookup() [here](https://github.com/frictionlessdata/framework/blob/5e092abae1167c6d8e452cb934b9f202ecf28801/frictionless/resource/resource.py#L720)
- fixes #1252

Need feedback as I am not sure if the solution that I have given is the right way.

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
