### PR TITLE
Replaced iteritems with items

### DIFF
--- a/frictionless/formats/pandas/parser.py
+++ b/frictionless/formats/pandas/parser.py
@@ -63,7 +63,7 @@ class PandasParser(Parser):
                 schema.primary_key.append(name)
 
         # Fields
-        for name, dtype in dataframe.dtypes.iteritems():  # type: ignore
+        for name, dtype in dataframe.dtypes.items():  # type: ignore
             sample = dataframe[name].iloc[0] if len(dataframe) else None  # type: ignore
             type = self.__read_convert_type(dtype, sample=sample)
             field = Field.from_descriptor({"name": name, "type": type})


### PR DESCRIPTION
- Replaced iteritems with items. Iteritems is deprecated.
- fixes #1284

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
