### PR TITLE
475/adds ckan dataportal

### DIFF
--- a/docs/portals/ckan.md
+++ b/docs/portals/ckan.md
@@ -22,10 +22,10 @@ from frictionless.portals import CkanControl
 from frictionless import Package
 
 ckan_control = CkanControl()
-package = Package('https://dados.gov.br/dataset/bolsa-familia-pagamentos', control=ckan_control)
+package = Package('https://legado.dados.gov.br/dataset/bolsa-familia-pagamentos', control=ckan_control)
 ```
 
-Where 'https://dados.gov.br/dataset/bolsa-familia-pagamentos' is the URL for
+Where 'https://legado.dados.gov.br/dataset/bolsa-familia-pagamentos' is the URL for
 the CKAN dataset. This will download the dataset and all its resources
 metadata.
 
@@ -36,7 +36,7 @@ base URL (`baseurl`) and the dataset that you do want to download (`dataset`):
 from frictionless.portals import CkanControl
 from frictionless import Package
 
-ckan_control = CkanControl(baseurl='https://dados.gov.br', dataset='bolsa-familia-pagamentos')
+ckan_control = CkanControl(baseurl='https://legado.dados.gov.br', dataset='bolsa-familia-pagamentos')
 package = Package(control=ckan_control)
 ```
 
@@ -47,7 +47,7 @@ you pass only the `baseurl` you can download a package as:
 from frictionless.portals import CkanControl
 from frictionless import Package
 
-ckan_control = CkanControl(baseurl='https://dados.gov.br')
+ckan_control = CkanControl(baseurl='https://legado.dados.gov.br')
 package = Package('bolsa-familia-pagamentos', control=ckan_control)
 ```
 
@@ -61,7 +61,7 @@ CKAN Control:
 from frictionless.portals import CkanControl
 from frictionless import Package
 
-ckan_control = CkanControl(baseurl='https://dados.gov.br', ignore_schema=True)
+ckan_control = CkanControl(baseurl='https://legado.dados.gov.br', ignore_schema=True)
 package = Package('bolsa-familia-pagamentos', control=ckan_control)
 ```
 
@@ -78,7 +78,7 @@ Control as the parameter `apikey`.
 from frictionless.portals import CkanControl
 from frictionless import Package
 
-ckan_control = CkanControl(baseurl='https://dados.gov.br', apikey='YOUR-SECRET-API-KEY')
+ckan_control = CkanControl(baseurl='https://legado.dados.gov.br', apikey='YOUR-SECRET-API-KEY')
 package = Package(...) # Create your package
 package.publish(control=ckan_control)
 ```
@@ -92,7 +92,7 @@ You can download a list of CKAN datasets using the Catalog.
 import frictionless
 from frictionless import portals, Catalog
     
-ckan_control = portals.CkanControl(baseurl='https://dados.gov.br')
+ckan_control = portals.CkanControl(baseurl='https://legado.dados.gov.br')
 c = Catalog(control=ckan_control)
 ```
 
@@ -107,7 +107,7 @@ datasets you can do as:
 import frictionless
 from frictionless import portals, Catalog
     
-ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', num_packages=1000)
+ckan_control = portals.CkanControl(baseurl='https://legado.dados.gov.br', num_packages=1000)
 c = Catalog(control=ckan_control)
 ```
 
@@ -123,7 +123,7 @@ pass the parameter `ignore_package_errors=True`:
 import frictionless
 from frictionless import portals, Catalog
     
-ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', ignore_package_erros=True, num_packages=1000)
+ckan_control = portals.CkanControl(baseurl='https://legado.dados.gov.br', ignore_package_errors=True, num_packages=1000)
 c = Catalog(control=ckan_control)
 ```
 
@@ -145,7 +145,7 @@ You can see in the example above that 1000 packages were download from a total
 import frictionless
 from frictionless import portals, Catalog
     
-ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', ignore_package_erros=True, results_offset=1000)
+ckan_control = portals.CkanControl(baseurl='https://legado.dados.gov.br', ignore_package_erros=True, results_offset=1000)
 c = Catalog(control=ckan_control)
 ```
 
@@ -155,7 +155,7 @@ This will download 1000 packages after the the first 1000 packages.
 
 To fetch all packages from a organization will can use the CKAN Control
 parameter `organization_name`. e.g. if you want to fetch all datasets from the
-organization `https://dados.gov.br/organization/agencia-espacial-brasileira-aeb` you can do
+organization `https://legado.dados.gov.br/organization/agencia-espacial-brasileira-aeb` you can do
 as follows:
 
 
@@ -163,7 +163,7 @@ as follows:
 import frictionless
 from frictionless import portals, Catalog
     
-ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', organization_name='agencia-espacial-brasileira-aeb')
+ckan_control = portals.CkanControl(baseurl='https://legado.dados.gov.br', organization_name='agencia-espacial-brasileira-aeb')
 c = Catalog(control=ckan_control)
 ```
 
@@ -174,7 +174,7 @@ the parameter `group_id` to the CKAN Control as:
 import frictionless
 from frictionless import portals, Catalog
     
-ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', group_id='ciencia-informacao-e-comunicacao')
+ckan_control = portals.CkanControl(baseurl='https://legado.dados.gov.br', group_id='ciencia-informacao-e-comunicacao')
 c = Catalog(control=ckan_control)
 ```
 
@@ -188,7 +188,7 @@ You can pass the search parameters as the parameter `search` to CKAN Control.
 import frictionless
 from frictionless import portals, Catalog
     
-ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', search={'q': 'name:bolsa*'})
+ckan_control = portals.CkanControl(baseurl='https://legado.dados.gov.br', search={'q': 'name:bolsa*'})
 c = Catalog(control=ckan_control)
 ```
 

--- a/docs/portals/ckan.md
+++ b/docs/portals/ckan.md
@@ -1,5 +1,38 @@
 # Ckan Portal
 
-```markdown remark type=danger
-This functionality is currently disabled as being in active development in [#475](https://github.com/frictionlessdata/frictionless-py/issues/475)
+With CKAN portal feature you can load and publish packages from a [CKAN](https://ckan.org), an open-source Data Management System.
+
+# Installation
+
+To install this plugin you need to do:
+
+```bash tabs=CLI
+pip install frictionless[ckan] --pre
+pip install 'frictionless[ckan]' --pre # for zsh shell
 ```
+
+# Configuring the CKAN control
+
+The first thing that you need to do before trying to load a package from CKAN is configure a CKAN control. For that you can import `CkanControl` 
+and pass the base URL from your CKAN instance. 
+
+```python tabs=Python
+from frictionless.portals import CkanControl
+
+ckan_control = CkanControl(baseurl='https://dados.gov.br')
+```
+
+# Reading a package
+
+
+# Publishing a package
+
+# Reading a Catalog
+
+# Reference
+
+```yaml reference
+references:
+  - frictionless.portals.CkanControl
+```
+

--- a/docs/portals/ckan.md
+++ b/docs/portals/ckan.md
@@ -1,6 +1,7 @@
 # Ckan Portal
 
-With CKAN portal feature you can load and publish packages from a [CKAN](https://ckan.org), an open-source Data Management System.
+With CKAN portal feature you can load and publish packages from a
+[CKAN](https://ckan.org), an open-source Data Management System.
 
 # Installation
 
@@ -11,23 +12,185 @@ pip install frictionless[ckan] --pre
 pip install 'frictionless[ckan]' --pre # for zsh shell
 ```
 
-# Configuring the CKAN control
+# Reading a Package
 
-The first thing that you need to do before trying to load a package from CKAN is configure a CKAN control. For that you can import `CkanControl` 
-and pass the base URL from your CKAN instance. 
+To import a Dataset from a CKAN instance as a Frictionless Package you can do
+as below:
 
 ```python tabs=Python
 from frictionless.portals import CkanControl
+from frictionless import Package
 
-ckan_control = CkanControl(baseurl='https://dados.gov.br')
+ckan_control = CkanControl()
+package = Package.from_ckan('https://dados.gov.br/dataset/bolsa-familia-pagamentos', control=ckan_control)
 ```
 
-# Reading a package
+Where 'https://dados.gov.br/dataset/bolsa-familia-pagamentos' is the URL for
+the CKAN dataset. This will download the dataset and all its resources
+metadata.
 
+You can pass parameters to CKAN Control to configure it, like the CKAN instance
+base URL (`baseurl`) and the dataset that you do want to download (`dataset`):
+
+```python tabs=Python
+from frictionless.portals import CkanControl
+from frictionless import Package
+
+ckan_control = CkanControl(baseurl='https://dados.gov.br', dataset='bolsa-familia-pagamentos')
+package = Package(control=ckan_control)
+```
+
+You don't need to pass the `dataset` parameter to CkanControl. In the case that
+you pass only the `baseurl` you can download a package as:
+
+```python tabs=Python
+from frictionless.portals import CkanControl
+from frictionless import Package
+
+ckan_control = CkanControl(baseurl='https://dados.gov.br')
+package = Package.from_ckan('bolsa-familia-pagamentos', control=ckan_control)
+```
+
+## Ignoring a Resource Schema
+
+In case that the CKAN dataset has a resource containing errors in its schema,
+you still can load the package passing the parameter `ignore_schema=True` to
+CKAN Control:
+
+```python tabs=Python
+from frictionless.portals import CkanControl
+from frictionless import Package
+
+ckan_control = CkanControl(baseurl='https://dados.gov.br', ignore_schema=True)
+package = Package.from_ckan('bolsa-familia-pagamentos', control=ckan_control)
+```
+
+This will download the dataset and all its resources, saving the resources'
+original schemas on `original_schema`.
 
 # Publishing a package
 
+To publish a Package to a CKAN instance you will need an API key from an CKAN's
+user that has permission to create datasets. This key can be passed to CKAN
+Control as the parameter `apikey`.
+
+```python tabs=Python
+from frictionless.portals import CkanControl
+from frictionless import Package
+
+ckan_control = CkanControl(baseurl='https://dados.gov.br', apikey='YOUR-SECRET-API-KEY')
+package = Package() # Create your package
+package.publish(control=ckan_control)
+```
+
 # Reading a Catalog
+
+You can download a list of CKAN datasets using the Catalog.
+
+```python tabs=Python
+
+import frictionless
+from frictionless import portals, Catalog
+    
+ckan_control = portals.CkanControl(baseurl='https://dados.gov.br')
+c = Catalog(control=ckan_control)
+```
+
+This will download all datasets from the instance, limited only by the maximum
+number of datasets returned by the instance CKAN API. If the instance returns
+only 10 datasets as default, you can request more packages passing the
+parameter `num_packages`. In the example above if you want to download 1000
+datasets you can do as:
+
+```python tabs=Python
+
+import frictionless
+from frictionless import portals, Catalog
+    
+ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', num_packages=1000)
+c = Catalog(control=ckan_control)
+```
+
+It's possible that when you are requesting a large number of packages from
+CKAN, that some of them don't have a valid Package descriptor according to the
+specifications. In that case the standard behaviour will be to stop downloading
+a raise an exception. If you want to ignore individual package errors, you can
+pass the parameter `ignore_package_errors=True`:
+
+
+```python tabs=Python
+
+import frictionless
+from frictionless import portals, Catalog
+    
+ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', ignore_package_erros=True, num_packages=1000)
+c = Catalog(control=ckan_control)
+```
+
+And the output of the command above will be the CKAN datasets ids with errors
+and the total number of packages returned by your query to the CKAN instance:
+
+```
+Error in CKAN dataset 8d60eff7-1a46-42ef-be64-e8979117a378: [package-error] The data package has an error: descriptor is not valid (The data package has an error: property "contributors[].email" is not valid "email")
+Error in CKAN dataset 933d7164-8128-4e12-97e6-208bc4935bcb: [package-error] The data package has an error: descriptor is not valid (The data package has an error: property "contributors[].email" is not valid "email")
+Error in CKAN dataset 93114fec-01c2-4ef5-8dfe-67da5027d568: [package-error] The data package has an error: descriptor is not valid (The data package has an error: property "contributors[].email" is not valid "email") (The data package has an error: property "contributors[].email" is not valid "email")
+Total number of packages: 13786
+```
+
+You can see in the example above that 1000 packages were download from a total
+13786 packages. You can download other packages passing an offset as:
+
+```python tabs=Python
+
+import frictionless
+from frictionless import portals, Catalog
+    
+ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', ignore_package_erros=True, results_offset=1000)
+c = Catalog(control=ckan_control)
+```
+
+This will download 1000 packages after the the first 1000 packages. 
+
+## Fetching the datasets from an Organization or Group
+
+To fetch all packages from a organization will can use the CKAN Control
+parameter `organization_name`. e.g. if you want to fetch all datasets from the
+organization `https://dados.gov.br/organization/agencia-espacial-brasileira-aeb` you can do
+as follows:
+
+
+```python tabs=Python
+import frictionless
+from frictionless import portals, Catalog
+    
+ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', organization_name='agencia-espacial-brasileira-aeb')
+c = Catalog(control=ckan_control)
+```
+
+Similarly, if you want to download all datasets from a CKAN Group you can pass
+the parameter `group_id` to the CKAN Control as:
+
+```python tabs=Python
+import frictionless
+from frictionless import portals, Catalog
+    
+ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', group_id='ciencia-informacao-e-comunicacao')
+c = Catalog(control=ckan_control)
+```
+
+## Using CKAN search
+
+You can also fetch only the datasets that are returned by the [CKAN Package
+Search endpoint](https://docs.ckan.org/en/2.9/api/#ckan.logic.action.get.package_search).
+You can pass the search parameters as the parameter `search` to CKAN Control.
+
+```python tabs=Python
+import frictionless
+from frictionless import portals, Catalog
+    
+ckan_control = portals.CkanControl(baseurl='https://dados.gov.br', search={'q': 'name:bolsa*'})
+c = Catalog(control=ckan_control)
+```
 
 # Reference
 
@@ -35,4 +198,3 @@ ckan_control = CkanControl(baseurl='https://dados.gov.br')
 references:
   - frictionless.portals.CkanControl
 ```
-

--- a/docs/portals/ckan.md
+++ b/docs/portals/ckan.md
@@ -22,7 +22,7 @@ from frictionless.portals import CkanControl
 from frictionless import Package
 
 ckan_control = CkanControl()
-package = Package.from_ckan('https://dados.gov.br/dataset/bolsa-familia-pagamentos', control=ckan_control)
+package = Package('https://dados.gov.br/dataset/bolsa-familia-pagamentos', control=ckan_control)
 ```
 
 Where 'https://dados.gov.br/dataset/bolsa-familia-pagamentos' is the URL for
@@ -48,7 +48,7 @@ from frictionless.portals import CkanControl
 from frictionless import Package
 
 ckan_control = CkanControl(baseurl='https://dados.gov.br')
-package = Package.from_ckan('bolsa-familia-pagamentos', control=ckan_control)
+package = Package('bolsa-familia-pagamentos', control=ckan_control)
 ```
 
 ## Ignoring a Resource Schema
@@ -62,7 +62,7 @@ from frictionless.portals import CkanControl
 from frictionless import Package
 
 ckan_control = CkanControl(baseurl='https://dados.gov.br', ignore_schema=True)
-package = Package.from_ckan('bolsa-familia-pagamentos', control=ckan_control)
+package = Package('bolsa-familia-pagamentos', control=ckan_control)
 ```
 
 This will download the dataset and all its resources, saving the resources'
@@ -79,7 +79,7 @@ from frictionless.portals import CkanControl
 from frictionless import Package
 
 ckan_control = CkanControl(baseurl='https://dados.gov.br', apikey='YOUR-SECRET-API-KEY')
-package = Package() # Create your package
+package = Package(...) # Create your package
 package.publish(control=ckan_control)
 ```
 

--- a/frictionless/platform.py
+++ b/frictionless/platform.py
@@ -232,6 +232,13 @@ class Platform:
         return frictionless_ckan_mapper.ckan_to_frictionless
 
     @cached_property
+    @extras(name="ckan")
+    def frictionless_ckan_mapper_frictionless_to_ckan(self):
+        import frictionless_ckan_mapper.frictionless_to_ckan
+
+        return frictionless_ckan_mapper.frictionless_to_ckan
+
+    @cached_property
     @extras(name="excel")
     def xlrd(self):
         import xlrd

--- a/frictionless/portals/ckan/adapter.py
+++ b/frictionless/portals/ckan/adapter.py
@@ -28,7 +28,7 @@ class CkanAdapter(Adapter):
         endpoint: str = ""
         response: dict = {}
         descriptor: dict = {}
-        num_packages: int = None
+        num_packages: Union[int, None] = None
 
         assert self.control.baseurl
         if self.control.group_id:

--- a/frictionless/portals/ckan/adapter.py
+++ b/frictionless/portals/ckan/adapter.py
@@ -1,6 +1,6 @@
 import os
 import json
-from typing import Optional
+from typing import TYPE_CHECKING, Optional, List, Union
 from ...exception import FrictionlessException
 from ...system import system, Adapter
 from ...platform import platform
@@ -13,52 +13,150 @@ from .control import CkanControl
 class CkanAdapter(Adapter):
     """Read and write data from/to Ckan"""
 
+    mapper = {
+        "ckan_to_fric": platform.frictionless_ckan_mapper_ckan_to_frictionless,
+        "fric_to_ckan": platform.frictionless_ckan_mapper_frictionless_to_ckan,
+    }
+
     def __init__(self, control: CkanControl):
         self.control = control
 
-    # Read
+    # Read a set of CKAN datasets as a Catalog
+    def read_catalog(self) -> Catalog:
+        packages: List[Union[Package, str]] = []
+        params = {}
+        endpoint: str = ""
+        response: dict = {}
+        descriptor: dict = {}
 
-    # TODO: improve
-    def read_catalog(self):
+        search_endpoint = False
         assert self.control.baseurl
-        endpoint = f"{self.control.baseurl}/api/3/action/package_list"
-        response = make_ckan_request(endpoint)
-        catalog = Catalog()
-        for dataset in response["result"]:
-            package = self.read_package(dataset=dataset)
-            catalog.add_package(package)
-        return catalog
+        if (
+            not self.control.group_id
+            and not self.control.organization_name
+            and not self.control.search
+        ):
+            # Get all packages from a CKAN instance
+            endpoint = f"{self.control.baseurl}/api/3/action/package_list"
+        elif self.control.group_id:
+            # Search only packages from a group
+            params = {"id": self.control.group_id}
+            endpoint = f"{self.control.baseurl}/api/3/action/group_package_show"
+        elif self.control.organization_name:
+            # Search only packages from an organization using search
+            params = {"q": f"organization:{self.control.organization_name}"}
+            endpoint = f"{self.control.baseurl}/api/3/action/package_search"
+            search_endpoint = True
+        elif self.control.search:
+            params = self.control.search
+            endpoint = f"{self.control.baseurl}/api/3/action/package_search"
+            search_endpoint = True
 
-    # TODO: improve
-    def read_package(self, *, dataset: Optional[str] = None):
-        mapper = platform.frictionless_ckan_mapper_ckan_to_frictionless
+        if endpoint:
+            response = make_ckan_request(endpoint, params=params)
+
+        results = []
+        if search_endpoint:
+            results = response["result"]["results"]
+        else:
+            results = response["result"]
+
+        for dataset in results:
+            try:
+                descriptor = self.mapper["ckan_to_fric"].dataset(dataset)
+                package = Package.from_descriptor(descriptor)
+                packages.append(package)
+            except FrictionlessException as e:
+                if self.control.ignore_package_errors:
+                    print(f'Error in CKAN dataset {descriptor["id"]}: {e}')
+                    continue
+                else:
+                    raise e
+
+        return Catalog(name="catalog", packages=packages)
+
+    # Read a package from a CKAN instance
+    def read_package(self, *, dataset: Optional[str] = None) -> Package:
         baseurl = self.control.baseurl
         dataset = dataset or self.control.dataset
         assert baseurl
         assert dataset
         params = {"id": dataset}
+        args = {}
+
+        if self.control.apikey:
+            args["apikey"] = self.control.apikey
+
         endpoint = f"{self.control.baseurl}/api/3/action/package_show"
-        response = make_ckan_request(endpoint, params=params)
-        descriptor = mapper.dataset(response["result"])
-        package = Package.from_descriptor(descriptor)
+        response = make_ckan_request(endpoint, **args, params=params)
+        descriptor = self.mapper["ckan_to_fric"].dataset(response["result"])
+
+        try:
+            package = Package.from_descriptor(descriptor)
+        except FrictionlessException as e:
+            if self.control.ignore_schema:
+                for res in descriptor["resources"]:
+                    del res["schema"]
+                package = Package.from_descriptor(descriptor)
+            else:
+                raise e
+
         for path in package.resource_paths:
-            if path.endswith(("/datapackage.json", "/datapackage.yaml")):
+            if (
+                path.endswith(("/datapackage.json", "/datapackage.yaml"))
+                and not self.control.ignore_schema
+            ):
                 return Package.from_descriptor(path)
+
         for resource in package.resources:
             resource.name = helpers.slugify(resource.name)
             if resource.format:
                 resource.format = resource.format.lower()
+
         return package
 
-    # Write
-    # TODO: implement
+    # Write a Package to a CKAN instance as a dataset
+    def write_package(self, package: Package) -> Union[None, str]:
+        baseurl = self.control.baseurl
+        endpoint = f"{baseurl}/api/action/package_create"
+        headers = {}
+
+        if self.control.apikey:
+            if self.control.apikey.startswith("env:"):
+                apikey = os.environ.get(self.control.apikey[4:])
+            else:
+                apikey = self.control.apikey
+
+            headers.update({"Authorization": apikey})
+
+        package_data = self.mapper["fric_to_ckan"].package(package.to_descriptor())
+        try:
+            # Make request
+            response = system.http_session.request(
+                method="POST",
+                url=endpoint,
+                headers=headers,
+                allow_redirects=True,
+                json=package_data,
+            )
+
+            if response.status_code == 200:
+                response_dict = json.loads(response.content)
+                dataset_id = response_dict["result"]["id"]
+
+                return f"{self.control.baseurl}/dataset/{dataset_id}"
+
+        except Exception as exception:
+            note = "CKAN API error:" + repr(exception)
+            raise FrictionlessException(note)
 
 
 # Internal
+def make_ckan_request(
+    endpoint, *, method="GET", headers=None, apikey=None, **options
+) -> dict:
 
-
-def make_ckan_request(endpoint, *, method="GET", headers=None, apikey=None, **options):
-
+    response_json: dict = {}
     # Handle headers
     if headers is None:
         headers = {}
@@ -72,17 +170,20 @@ def make_ckan_request(endpoint, *, method="GET", headers=None, apikey=None, **op
     # Make request
     response = system.http_session.request(
         method=method, url=endpoint, headers=headers, allow_redirects=True, **options
-    ).json()
+    )
+
+    if response:
+        response_json = response.json()
 
     # Handle error
     try:
         ckan_error = None
-        if not response["success"] and response["error"]:
-            ckan_error = response["error"]
+        if not response_json["success"] and response_json["error"]:
+            ckan_error = response_json["error"]
     except TypeError:
         ckan_error = response
     if ckan_error:
         note = "CKAN returned an error: " + json.dumps(ckan_error)
         raise FrictionlessException(note)
 
-    return response
+    return response_json

--- a/frictionless/portals/ckan/adapter.py
+++ b/frictionless/portals/ckan/adapter.py
@@ -29,16 +29,8 @@ class CkanAdapter(Adapter):
         response: dict = {}
         descriptor: dict = {}
 
-        search_endpoint = False
         assert self.control.baseurl
-        if (
-            not self.control.group_id
-            and not self.control.organization_name
-            and not self.control.search
-        ):
-            # Get all packages from a CKAN instance
-            endpoint = f"{self.control.baseurl}/api/3/action/package_list"
-        elif self.control.group_id:
+        if self.control.group_id:
             # Search only packages from a group
             params = {"id": self.control.group_id}
             endpoint = f"{self.control.baseurl}/api/3/action/group_package_show"
@@ -46,20 +38,16 @@ class CkanAdapter(Adapter):
             # Search only packages from an organization using search
             params = {"q": f"organization:{self.control.organization_name}"}
             endpoint = f"{self.control.baseurl}/api/3/action/package_search"
-            search_endpoint = True
         elif self.control.search:
             params = self.control.search
             endpoint = f"{self.control.baseurl}/api/3/action/package_search"
-            search_endpoint = True
-
-        if endpoint:
-            response = make_ckan_request(endpoint, params=params)
-
-        results = []
-        if search_endpoint:
-            results = response["result"]["results"]
         else:
-            results = response["result"]
+            # Get all packages from a CKAN instance
+            params = {"q": "*:*"}
+            endpoint = f"{self.control.baseurl}/api/3/action/package_search"
+
+        response = make_ckan_request(endpoint, params=params)
+        results = response["result"]["results"]
 
         for dataset in results:
             try:

--- a/frictionless/portals/ckan/adapter.py
+++ b/frictionless/portals/ckan/adapter.py
@@ -28,6 +28,7 @@ class CkanAdapter(Adapter):
         endpoint: str = ""
         response: dict = {}
         descriptor: dict = {}
+        num_packages: int = None
 
         assert self.control.baseurl
         if self.control.group_id:
@@ -58,6 +59,7 @@ class CkanAdapter(Adapter):
         response = make_ckan_request(endpoint, params=params)
         if not self.control.group_id:
             results = response["result"]["results"]
+            num_packages = response["result"]["count"]
         else:
             results = response["result"]
 
@@ -72,6 +74,9 @@ class CkanAdapter(Adapter):
                     continue
                 else:
                     raise e
+
+        if num_packages:
+            print(f"Total number of packages: {num_packages}")
 
         return Catalog(name="catalog", packages=packages)
 

--- a/frictionless/portals/ckan/control.py
+++ b/frictionless/portals/ckan/control.py
@@ -14,16 +14,13 @@ class CkanControl(Control):
 
     baseurl: Optional[str] = None
     """
-    Endpoint url for CKAN instance.
+    Endpoint url for CKAN instance. e.g. https://dados.gov.br
     """
 
     dataset: Optional[str] = None
     """
     Unique identifier of the dataset to read.
     """
-
-    resource: Optional[str] = None
-    """NOTE: add docs"""
 
     apikey: Optional[str] = None
     """
@@ -54,7 +51,17 @@ class CkanControl(Control):
 
     search: Optional[dict] = None
     """
-    CKAN Organization name to get datasets in a Catalog
+    CKAN Search parameters as defined on https://docs.ckan.org/en/2.9/api/#ckan.logic.action.get.package_search
+    """
+
+    num_packages: Optional[int] = None
+    """
+    Maximum number of packages to fetch
+    """
+
+    results_offset: Optional[int] = None
+    """
+    Results page number
     """
 
     # Metadata
@@ -63,12 +70,13 @@ class CkanControl(Control):
         "properties": {
             "baseurl": {"type": "string"},
             "dataset": {"type": "string"},
-            "resource": {"type": "string"},
             "apikey": {"type": "string"},
             "group_id": {"type": "string"},
             "organization_name": {"type": "string"},
-            "search": {"type": "string"},
+            "search": {"type": "object"},
             "ignore_package_errors": {"type": "bool"},
             "ignore_schema": {"type": "bool"},
+            "num_packages": {"type": "int"},
+            "results_offset": {"type": "int"},
         },
     }

--- a/frictionless/portals/ckan/control.py
+++ b/frictionless/portals/ckan/control.py
@@ -64,6 +64,11 @@ class CkanControl(Control):
     Results page number
     """
 
+    allow_update: Optional[bool] = False
+    """
+    Update a dataset on publish with an id is provided on the package descriptor
+    """
+
     # Metadata
 
     metadata_profile_patch = {
@@ -78,5 +83,6 @@ class CkanControl(Control):
             "ignore_schema": {"type": "bool"},
             "num_packages": {"type": "int"},
             "results_offset": {"type": "int"},
+            "allow_update": {"type": "bool"},
         },
     }

--- a/frictionless/portals/ckan/control.py
+++ b/frictionless/portals/ckan/control.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import attrs
-from typing import Optional, List
+from typing import Optional
 from ...dialect import Control
 
 

--- a/frictionless/portals/ckan/control.py
+++ b/frictionless/portals/ckan/control.py
@@ -31,25 +31,30 @@ class CkanControl(Control):
     to write files to CKAN instance.
     """
 
-    fields: Optional[List[str]] = None
+    ignore_package_errors: Optional[bool] = False
     """
-    Specify the number of fields to read. Other fields
-    will not be read.
-    """
-
-    limit: Optional[int] = None
-    """
-    Limit the number of records to read.
+    Ignore Package errors in a Catalog. If multiple packages are being downloaded
+    and one fails with an invalid descriptor, continue downloading the rest.
     """
 
-    sort: Optional[str] = None
+    ignore_schema: Optional[bool] = False
     """
-    Field by which to sort the data before reading the data.
+    Ignore dataset resources schemas
     """
 
-    filters: Optional[dict] = None
+    group_id: Optional[str] = None
     """
-    Params as a list of dict to filter the data while reading.
+    CKAN Group id to get datasets in a Catalog
+    """
+
+    organization_name: Optional[str] = None
+    """
+    CKAN Organization name to get datasets in a Catalog
+    """
+
+    search: Optional[dict] = None
+    """
+    CKAN Organization name to get datasets in a Catalog
     """
 
     # Metadata
@@ -60,9 +65,10 @@ class CkanControl(Control):
             "dataset": {"type": "string"},
             "resource": {"type": "string"},
             "apikey": {"type": "string"},
-            "fields": {"type": "array", "items": {"type": "string"}},
-            "limit": {"type": "integer"},
-            "sort": {"type": "string"},
-            "filters": {"type": "object"},
+            "group_id": {"type": "string"},
+            "organization_name": {"type": "string"},
+            "search": {"type": "string"},
+            "ignore_package_errors": {"type": "bool"},
+            "ignore_schema": {"type": "bool"},
         },
     }

--- a/frictionless/portals/ckan/plugin.py
+++ b/frictionless/portals/ckan/plugin.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 from ...system import Plugin
 from urllib.parse import urlparse
+from typing import TYPE_CHECKING, Optional
 from .control import CkanControl
 from .adapter import CkanAdapter
+
+if TYPE_CHECKING:
+    from ... import portals
 
 
 class CkanPlugin(Plugin):
@@ -21,7 +25,11 @@ class CkanPlugin(Plugin):
                     control.baseurl = baseurl
                     if dataset:
                         control.dataset = dataset
+
+                if isinstance(control, CkanControl):
                     return CkanAdapter(control)
+        if not source and isinstance(control, CkanControl):
+            return CkanAdapter(control)
 
     def select_Control(self, type):
         if type == "ckan":

--- a/frictionless/portals/ckan/plugin.py
+++ b/frictionless/portals/ckan/plugin.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 from ...system import Plugin
 from urllib.parse import urlparse
-from typing import TYPE_CHECKING, Optional
 from .control import CkanControl
 from .adapter import CkanAdapter
-
-if TYPE_CHECKING:
-    from ... import portals
 
 
 class CkanPlugin(Plugin):

--- a/frictionless/portals/ckan/plugin.py
+++ b/frictionless/portals/ckan/plugin.py
@@ -21,10 +21,15 @@ class CkanPlugin(Plugin):
             if not control or isinstance(control, CkanControl):
                 if parsed.path.startswith("/dataset/"):
                     control = control or CkanControl()
-                    baseurl, dataset = source.split("/dataset/")
-                    control.baseurl = baseurl
+                    if not control.baseurl:
+                        baseurl, dataset = source.split("/dataset/")
+                        control.baseurl = baseurl
+                    else:
+                        dataset = source.split("/dataset/")[1]
                     if dataset:
                         control.dataset = dataset
+                elif control:
+                    control.dataset = source
 
                 if isinstance(control, CkanControl):
                     return CkanAdapter(control)

--- a/frictionless/resource/resource.py
+++ b/frictionless/resource/resource.py
@@ -836,14 +836,11 @@ class Resource(Metadata):
                                 continue
                             match = cells in group_lookup.get(group["sourceKey"], set())
                             if not match:
-                                note = (
-                                    'for "%s": values "%s" not found in the lookup table "%s" as "%s"'
-                                    % (
-                                        ", ".join(group["targetKey"]),
-                                        ", ".join(str(d) for d in cells),
-                                        group["sourceName"],
-                                        ", ".join(group["sourceKey"]),
-                                    )
+                                note = 'for "%s": values "%s" not found in the lookup table "%s" as "%s"' % (
+                                    ", ".join(group["targetKey"]),
+                                    ", ".join(str(d) for d in cells),
+                                    group["sourceName"],
+                                    ", ".join(group["sourceKey"]),
                                 )
 
                                 error = errors.ForeignKeyError.from_row(

--- a/frictionless/resource/resource.py
+++ b/frictionless/resource/resource.py
@@ -836,11 +836,14 @@ class Resource(Metadata):
                                 continue
                             match = cells in group_lookup.get(group["sourceKey"], set())
                             if not match:
-                                note = 'for "%s": values "%s" not found in the lookup table "%s" as "%s"' % (
-                                    ", ".join(group["targetKey"]),
-                                    ", ".join(str(d) for d in cells),
-                                    group["sourceName"],
-                                    ", ".join(group["sourceKey"]),
+                                note = (
+                                    'for "%s": values "%s" not found in the lookup table "%s" as "%s"'
+                                    % (
+                                        ", ".join(group["targetKey"]),
+                                        ", ".join(str(d) for d in cells),
+                                        group["sourceName"],
+                                        ", ".join(group["sourceKey"]),
+                                    )
                                 )
 
                                 error = errors.ForeignKeyError.from_row(


### PR DESCRIPTION
- fixes #475

This PR adds support to CKAN  as a data portal.

 - [x] Reading individual packages  
 - [x] Publishing individual packages to a CKAN instance
 - [x] Fetching a list of packages using CKAN search
 - [x] Documentation
 - [ ] Local tests
