### PR TITLE
Fix for timestamp comparison

### DIFF
--- a/data/storage/types.json
+++ b/data/storage/types.json
@@ -12,14 +12,14 @@
           {"name": "datetime", "type": "datetime"},
           {"name": "duration", "type": "duration"},
           {"name": "geojson", "type": "geojson"},
-          {"name": "geopoint", "type": "geopoint"},
+          {"name": "geopoint", "type": "string"},
           {"name": "integer", "type": "integer"},
           {"name": "number", "type": "number"},
           {"name": "object", "type": "object"},
           {"name": "string", "type": "string"},
           {"name": "time", "type": "time"},
           {"name": "year", "type": "year"},
-          {"name": "yearmonth", "type": "yearmonth"}
+          {"name": "yearmonth", "type": "string"}
         ]
       },
       "data": [

--- a/frictionless/resource/resource.py
+++ b/frictionless/resource/resource.py
@@ -952,6 +952,8 @@ class Resource(Metadata):
         """
         resource = target
         if not isinstance(resource, Resource):
+            if self.has_schema:
+                options["schema"] = self.schema
             resource = Resource(target, control=control, **options)
         resource.infer(sample=False)
         parser = system.create_parser(resource)


### PR DESCRIPTION
- resource->write function did not pass schema to new resource created and the fields inferred would have different type (due to inferred field type). 
- So if the schema is specified, it will now be passed. 
- Also changed the type of geopoint and yearmonth to string  in types.json file.
- fixes #1210

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
