### PR TITLE
1356/fix publish for GitHub with dialect as file

### DIFF
--- a/frictionless/package/package.py
+++ b/frictionless/package/package.py
@@ -362,7 +362,7 @@ class Package(Metadata):
         adapter = system.create_adapter(target, control=control)
         if not adapter:
             raise FrictionlessException(f"Not supported target: {target} or control")
-        response = adapter.write_package(self.to_copy())
+        response = adapter.write_package(self.to_copy(basepath=self.basepath))
         if not response:
             raise FrictionlessException("Not supported action")
         return response
@@ -387,10 +387,10 @@ class Package(Metadata):
 
     # Convert
 
-    def to_copy(self):
+    def to_copy(self, **options):
         """Create a copy of the package"""
         return super().to_copy(
-            resources=[resource.to_copy() for resource in self.resources]
+            resources=[resource.to_copy() for resource in self.resources], **options
         )
 
     def to_er_diagram(self, path: Optional[str] = None) -> str:

--- a/frictionless/portals/github/adapter.py
+++ b/frictionless/portals/github/adapter.py
@@ -147,6 +147,13 @@ class GithubAdapter(Adapter):
             raise FrictionlessException(note)
 
         # Write package file
+        descriptor = package.to_descriptor()
+        for key, resource in enumerate(package.resources):
+            descriptor["resources"][key].update(
+                {"dialect": resource.dialect.to_descriptor()}
+            )
+        package = package.from_descriptor(descriptor, basepath=package.basepath)
+
         content = package.to_json()
         package_path = self.control.filename or "datapackage.json"
         if self.control.basepath:

--- a/frictionless/portals/github/adapter.py
+++ b/frictionless/portals/github/adapter.py
@@ -187,7 +187,7 @@ class GithubAdapter(Adapter):
                 repository.create_file(
                     path=resource_path,
                     message="Create package.json",
-                    content=str(resource.read_bytes()),
+                    content=resource.read_bytes(),  # type: ignore
                     branch=branch,
                     committer=author,
                     author=author,


### PR DESCRIPTION
- Add additional parameters as options in package `copy` function. 
- Remove type conversion of byte string to 'str', the file content were written as byte string in github.
- Convert dialect to json object, if it is a file.
- fixes #1356

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
