### PR TITLE
Update a CKAN dataset using the package name Fix #1352

### DIFF
--- a/frictionless/portals/ckan/adapter.py
+++ b/frictionless/portals/ckan/adapter.py
@@ -142,11 +142,16 @@ class CkanAdapter(Adapter):
 
         # Assure that the package has a name
         if "name" not in package_data:
-            note = "Your package has no name. CKAN requires a name to publish a package"
-            raise FrictionlessException(note)
+            if not self.control.dataset:
+                note = (
+                    "Your package has no name. CKAN requires a name to publish a package"
+                )
+                raise FrictionlessException(note)
+            else:
+                package_data["name"] = self.control.dataset
 
         # if "id" exist and control is set to allow updates, try to update dataset
-        if "id" in package_data and self.control.allow_update:
+        if self.control.allow_update:
             endpoint = f"{baseurl}/api/action/package_update"
 
         try:

--- a/frictionless/portals/ckan/control.py
+++ b/frictionless/portals/ckan/control.py
@@ -19,7 +19,7 @@ class CkanControl(Control):
 
     dataset: Optional[str] = None
     """
-    Unique identifier of the dataset to read.
+    Unique identifier of the dataset to read or write.
     """
 
     apikey: Optional[str] = None


### PR DESCRIPTION
- fixes #1352

It works as discussed, if the package has an id or name, if you pass allow_update to the control, the framework tries to update a package with the same name. 