### PR TITLE
Upload each individual package resource using the CKAN API 

### DIFF
--- a/frictionless/portals/ckan/adapter.py
+++ b/frictionless/portals/ckan/adapter.py
@@ -127,7 +127,6 @@ class CkanAdapter(Adapter):
         baseurl = self.control.baseurl
         endpoint = f"{baseurl}/api/action/package_create"
         headers = set_headers(self)
-        package.resources = remote_resources
         package_descriptor = package.to_descriptor()
         package_data = self.mapper["fric_to_ckan"].package(package_descriptor)
 
@@ -145,8 +144,8 @@ class CkanAdapter(Adapter):
         if self.control.allow_update:
             endpoint = f"{baseurl}/api/action/package_update"
 
-        # We will create he resources individually below
-        del package_data["resources"]
+        if "resources" in package_data:
+            del package_data["resources"]
 
         try:
             # Make request

--- a/frictionless/portals/ckan/adapter.py
+++ b/frictionless/portals/ckan/adapter.py
@@ -127,15 +127,6 @@ class CkanAdapter(Adapter):
         baseurl = self.control.baseurl
         endpoint = f"{baseurl}/api/action/package_create"
         headers = set_headers(self)
-
-        remote_resources = []
-        not_remote_resources = []
-        for res in package.resources:
-            if res.remote:
-                remote_resources.append(res)
-            else:
-                not_remote_resources.append(res)
-
         package.resources = remote_resources
         package_descriptor = package.to_descriptor()
         package_data = self.mapper["fric_to_ckan"].package(package_descriptor)
@@ -154,6 +145,9 @@ class CkanAdapter(Adapter):
         if self.control.allow_update:
             endpoint = f"{baseurl}/api/action/package_update"
 
+        # We will create he resources individually below
+        del package_data["resources"]
+
         try:
             # Make request
             response = system.http_session.request(
@@ -169,7 +163,8 @@ class CkanAdapter(Adapter):
                 dataset_id = response_dict["result"]["id"]
 
                 # upload resources
-                for resource in not_remote_resources:
+                # TODO: See if it's possible to upload only the resources that need to be uploaded
+                for resource in package.resources:
                     self.write_resource(dataset_id, resource)
 
                 return f"{self.control.baseurl}/dataset/{dataset_id}"


### PR DESCRIPTION
- fixes #1354

With this PR the adapter will create each individual resource using the CKAN API. Before, it would create just the resources that were not remote (resource.remote == True). We can use this approach anymore because external resources referenced in a datapackage or resources as {'path': 'https://example.com/res.csv', 'name': 'example resource'} are both detected as remote. Without the changes in this PR, the resources were being created two times, one using the API and other in the package descriptor.

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
