### PR TITLE
Fiy typo in basic example - transforming data

### DIFF
--- a/docs/basic-examples.md
+++ b/docs/basic-examples.md
@@ -205,7 +205,7 @@ pipeline = Pipeline(steps=[
 ])
 
 source = Resource('data/countries.csv')
-target = resource.transform(pipeline)
+target = source.transform(pipeline)
 pprint(target.read_rows())
 ```
 


### PR DESCRIPTION
- fixes #1420

---

A typo in the Python code in the Basic Examples section "Transforming data" yields an erroneous output.
