### PR TITLE
Constraint one column on another

### DIFF
--- a/frictionless/checks/baseline.py
+++ b/frictionless/checks/baseline.py
@@ -42,6 +42,7 @@ class baseline(Check):
         errors.BlankRowError,
         errors.PrimaryKeyError,
         errors.ForeignKeyError,
+        errors.RowConstraintError,
         # Cell
         errors.ExtraCellError,
         errors.MissingCellError,

--- a/tests/checklist/test_general.py
+++ b/tests/checklist/test_general.py
@@ -8,6 +8,7 @@ def test_checklist():
     assert checklist.check_types == ["ascii-value"]
     assert checklist.pick_errors == []
     assert checklist.skip_errors == []
+    print(checklist.scope)
     assert checklist.scope == [
         "hash-count",
         "byte-count",
@@ -22,6 +23,7 @@ def test_checklist():
         "blank-row",
         "primary-key",
         "foreign-key",
+        "row-constraint",
         "extra-cell",
         "missing-cell",
         "type-error",
@@ -62,6 +64,7 @@ def test_checklist_skip_errors():
         "blank-row",
         "primary-key",
         "foreign-key",
+        "row-constraint",
         "extra-cell",
         "missing-cell",
         "type-error",

--- a/tests/checklist/test_general.py
+++ b/tests/checklist/test_general.py
@@ -8,7 +8,6 @@ def test_checklist():
     assert checklist.check_types == ["ascii-value"]
     assert checklist.pick_errors == []
     assert checklist.skip_errors == []
-    print(checklist.scope)
     assert checklist.scope == [
         "hash-count",
         "byte-count",


### PR DESCRIPTION
- fixes #1521 
- The fix adds `row-constraint` in the checklist scope which was missing. We can now use the custom code to add row constraint as given in the added test
- Another solution would be to add additional fix to `row_constraint` step to include the function definitions in the `simpleeval`  

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
