### PR TITLE
Fix mypy error `error: invalid syntax [syntax]`

### DIFF
--- a/frictionless/resource/types.py
+++ b/frictionless/resource/types.py
@@ -11,7 +11,6 @@ from ..schema import ISchema
 # TODO: replace by frictionless-standards
 class IResource(TypedDict, total=False):
     name: Required[str]
-    #  type = required
     title: str
     description: str
     path: str

--- a/frictionless/schema/types.py
+++ b/frictionless/schema/types.py
@@ -18,7 +18,6 @@ class ISchema(TypedDict, total=False):
 
 class IField(TypedDict, total=False):
     name: Required[str]
-    #  type = required
     title: str
     description: str
     format: str


### PR DESCRIPTION
Hi again,

this patch intends to fix #1593. After applying it manually, the mypy type checker was able to work past this error. Apparently, it fails on the inline comments?

With kind regards,
Andreas.
