### PR TITLE
chore: fix minor typos

### DIFF
--- a/frictionless/analyzer/analyzer.py
+++ b/frictionless/analyzer/analyzer.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class Analyzer:
-    # Resoure
+    # Resource
 
     def analyze_table_resource(
         self, resource: TableResource, *, detailed: bool = False
@@ -100,7 +100,7 @@ class Analyzer:
                                     var_x.append(cell_x)
                                     var_y.append(cell_y)
 
-                            # check for atleast 2 data points for correlation calculation
+                            # check for at least 2 data points for correlation calculation
                             if len(var_x) > 2:
                                 if field.name not in analysis_report["correlations"]:
                                     analysis_report["correlations"][field.name] = []

--- a/frictionless/checks/baseline.py
+++ b/frictionless/checks/baseline.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class baseline(Check):
     """Check a table for basic errors
 
-    Ths check is enabled by default for any `validate` function run.
+    This check is enabled by default for any `validate` function run.
 
     """
 

--- a/frictionless/checks/row/row_constraint.py
+++ b/frictionless/checks/row/row_constraint.py
@@ -21,7 +21,7 @@ class row_constraint(Check):
 
     formula: str
     """
-    Python expression to apply to all rows. To evaluate the forumula
+    Python expression to apply to all rows. To evaluate the formula
     simpleeval library is used.
     """
 

--- a/frictionless/console/commands/transform.py
+++ b/frictionless/console/commands/transform.py
@@ -64,7 +64,7 @@ def console_transform(
         helpers.print_exception(console, debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
-    # TODO: support outputing packages
+    # TODO: support outputting packages
 
     # Return default
     table = result.to_petl()  # type: ignore

--- a/frictionless/console/common.py
+++ b/frictionless/console/common.py
@@ -321,7 +321,7 @@ standards = Option(
 
 descriptor = Option(
     default=None,
-    help="Excplicit path to the descriptor instead of guessing by providing a source",
+    help="Explicit path to the descriptor instead of guessing by providing a source",
 )
 
 keep_delimiter = Option(

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -38,7 +38,7 @@ class Detector:
 
     sample_size: int = settings.DEFAULT_SAMPLE_SIZE
     """
-    The amount of rows to be extracted as a sample for dialect/schema infering.
+    The amount of rows to be extracted as a sample for dialect/schema inferring.
     It defaults to 100. The sample_size can be increased to improve the inference
     accuracy.
     """
@@ -113,7 +113,7 @@ class Detector:
     Whether to sync the schema.
     If it sets to `True` the provided schema will be mapped to
     the inferred schema. It means that, for example, you can
-    provide a subset of fileds to be applied on top of the inferred
+    provide a subset of fields to be applied on top of the inferred
     fields or the provided schema can have different order of fields.
     """
 
@@ -265,7 +265,7 @@ class Detector:
         ):
             # This algorithm tries to find a header row
             # that is close to average sample width or use default one
-            # We use it to eleminate initial rows that are comments/etc
+            # We use it to eliminate initial rows that are comments/etc
 
             # Get header rows
             width = round(sum(widths) / len(widths))

--- a/frictionless/error/error.py
+++ b/frictionless/error/error.py
@@ -11,7 +11,7 @@ from ..platform import platform
 # NOTE:
 # Consider other approaches for report/errors as dict is not really
 # effective as it can be very memory consumig. As an option we can store
-# raw data without rendering an error template to an error messsage.
+# raw data without rendering an error template to an error message.
 
 
 @attrs.define(kw_only=True, repr=False)

--- a/frictionless/formats/csv/control.py
+++ b/frictionless/formats/csv/control.py
@@ -67,7 +67,7 @@ class CsvControl(Control):
     # Convert
 
     def to_python(self):
-        """Conver to Python's `csv.Dialect`"""
+        """Convert to Python's `csv.Dialect`"""
         config = csv.excel()
         config.delimiter = self.delimiter
         config.doublequote = self.double_quote if self.escape_char else True

--- a/frictionless/formats/csv/parser.py
+++ b/frictionless/formats/csv/parser.py
@@ -34,7 +34,7 @@ class CsvParser(Parser):
             config = csv.Sniffer().sniff("".join(sample), delimiter)  # type: ignore
         except csv.Error:
             config = csv.excel()
-        # We can't rely on this guess as it's can be confused with embeded JSON
+        # We can't rely on this guess as it's can be confused with embedded JSON
         # https://github.com/frictionlessdata/frictionless-py/issues/493
         if config.quotechar == "'":
             config.quotechar = '"'

--- a/frictionless/formats/excel/parsers/xlsx.py
+++ b/frictionless/formats/excel/parsers/xlsx.py
@@ -103,7 +103,7 @@ class XlsxParser(Parser):
         # Fill merged cells
         if control.fill_merged_cells:
             # NOTE:
-            # We can try using an algorithm similiar to what XlsParser has
+            # We can try using an algorithm similar to what XlsParser has
             # to support mergin cells in the read-only mode (now we need the write mode)
             for merged_cell_range in list(sheet.merged_cells.ranges):  # type: ignore
                 merged_cell_range = str(merged_cell_range)
@@ -306,7 +306,7 @@ def convert_excel_date_format_string(excel_date: str):
         )
         new_excel_code = False
 
-        # Handle a new code without a different characeter in between
+        # Handle a new code without a different character in between
         if (
             ec
             and not is_escape_char

--- a/frictionless/formats/parquet/plugin.py
+++ b/frictionless/formats/parquet/plugin.py
@@ -22,7 +22,7 @@ class ParquetPlugin(Plugin):
     def detect_resource(self, resource: Resource):
         if resource.format in ["parq", "parquet"]:
             resource.datatype = resource.datatype or "table"
-            resource.mediatype = resource.mediatype or "appliction/parquet"
+            resource.mediatype = resource.mediatype or "application/parquet"
 
     def select_control_class(self, type: Optional[str] = None):
         if type == "parquet":

--- a/frictionless/formats/sql/mapper.py
+++ b/frictionless/formats/sql/mapper.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 class SqlMapper(Mapper):
     """Metadata mapper Frictionless from/to SQL
 
-    Partialy based on unmerged @ezwelty's work:
+    Partially based on unmerged @ezwelty's work:
     - https://github.com/frictionlessdata/framework/pull/862
 
     """
@@ -208,7 +208,7 @@ class SqlMapper(Mapper):
         column_type = self.write_type(field.type)  # type: ignore
         nullable = not field.required
 
-        # Length contraints
+        # Length constraints
         if field.type == "string":
             min_length = field.constraints.get("minLength", None)
             max_length = field.constraints.get("maxLength", None)
@@ -227,14 +227,14 @@ class SqlMapper(Mapper):
                 if not isinstance(column_type, sa.CHAR) or self.dialect.name == "sqlite":
                     checks.append(Check("LENGTH(%s) >= %s" % (quoted_name, min_length)))
 
-        # Unique contstraint
+        # Unique constraint
         unique = field.constraints.get("unique", False)
         if self.dialect.name == "mysql":
             # MySQL requires keys to have an explicit maximum length
             # https://stackoverflow.com/questions/1827063/mysql-error-key-specification-without-a-key-length
             unique = unique and column_type is not sa.Text
 
-        # Others contstraints
+        # Others constraints
         for const, value in field.constraints.items():
             if const == "minimum":
                 checks.append(Check("%s >= %s" % (quoted_name, value)))

--- a/frictionless/helpers.py
+++ b/frictionless/helpers.py
@@ -207,7 +207,7 @@ def normalize_path(path: str, *, basepath: Optional[str] = None):
 
 # NOTE:
 # We need to rebase this function on checking actual path
-# being withing a basepath directory (it's a safer approach)
+# being within a basepath directory (it's a safer approach)
 def is_safe_path(path: str):
     contains_windows_var = lambda val: re.match(r"%.+%", val)  # type: ignore
     contains_posix_var = lambda val: re.match(r"\$.+", val)  # type: ignore

--- a/frictionless/metadata.py
+++ b/frictionless/metadata.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 class Metadata:
-    """Metadata represenation
+    """Metadata representation
 
     For proper functioning a child class must be decorated by
     "@attrs.define(kw_only=True, repr=False)" and ensure that
@@ -242,7 +242,7 @@ class Metadata:
     def to_markdown(self, path: Optional[str] = None, table: bool = False) -> str:
         """Convert metadata as a markdown
 
-        This feature has been contributed to the framwork by Ethan Welty (@ezwelty):
+        This feature has been contributed to the framework by Ethan Welty (@ezwelty):
         - https://github.com/frictionlessdata/frictionless-py/issues/837
 
         Parameters:

--- a/frictionless/package/package.py
+++ b/frictionless/package/package.py
@@ -355,11 +355,11 @@ class Package(Metadata, metaclass=Factory):
             dict: dict of resource analysis
 
         """
-        analisis: Dict[str, Any] = {}
+        analysis: Dict[str, Any] = {}
         for resource in self.resources:
             if isinstance(resource, platform.frictionless_resources.TableResource):
-                analisis[resource.name] = resource.analyze(detailed=detailed)
-        return analisis
+                analysis[resource.name] = resource.analyze(detailed=detailed)
+        return analysis
 
     # Describe
 
@@ -627,7 +627,7 @@ class Package(Metadata, metaclass=Factory):
                         yield errors.PackageError(note=f'path "{item}" is not safe')
                         return
 
-        # Resoruce Names
+        # Resource Names
         resource_names: List[str] = []
         for resource in descriptor["resources"]:
             if isinstance(resource, dict) and "name" in resource:
@@ -679,7 +679,7 @@ class Package(Metadata, metaclass=Factory):
         if profile == "tabular-data-package":
             for resource in resources:
                 if resource.get("profile", None) != "tabular-data-resource":
-                    note = 'profile "tabular-data-package" requries all the resources to be "tabular-data-resource"'
+                    note = 'profile "tabular-data-package" requires all the resources to be "tabular-data-resource"'
                     yield errors.PackageError(note=note)
 
         # Misleading

--- a/frictionless/pipeline/step.py
+++ b/frictionless/pipeline/step.py
@@ -16,10 +16,10 @@ if TYPE_CHECKING:
 
 # NOTE:
 # We might consider migrating transform_resource API to emitting
-# data as an ouput instead of setting it to target.data
+# data as an output instead of setting it to target.data
 # It might make custom transform steps more eloquent
 # This change probably not even breaking because it will be a new
-# mode supported by the system (function emiting data instead of returning None)
+# mode supported by the system (function emitting data instead of returning None)
 # We might consider adding `process_schema/row` etc to the Step class
 
 

--- a/frictionless/portals/github/adapter.py
+++ b/frictionless/portals/github/adapter.py
@@ -105,7 +105,7 @@ class GithubAdapter(Adapter):
                 repository.create_file(
                     path=resource_path,
                     message='Create "resource_path"',
-                    # It seeems to be it requries a string by a mistake
+                    # It seeems to be it requires a string by a mistake
                     # https://stackoverflow.com/questions/72668275/how-to-upload-an-image-file-to-github-using-pygithub
                     content=resource.read_bytes(),  # type: ignore
                     branch=branch,
@@ -122,7 +122,7 @@ class GithubAdapter(Adapter):
         # Enable pages
         if self.control.enable_pages:
             try:
-                # TODO: rebase on public API when it's avaialble
+                # TODO: rebase on public API when it's available
                 # https://github.com/PyGithub/PyGithub/issues/2037
                 repository._requester.requestJsonAndCheck(
                     "POST",

--- a/frictionless/portals/zenodo/control.py
+++ b/frictionless/portals/zenodo/control.py
@@ -43,7 +43,7 @@ class ZenodoControl(Control):
 
     base_url: str = BASE_URL
     """Endpoint for zenodo. By default it is set to live site (https://zenodo.org/api). For testing upload,
-    we can use sandbox for example, https://sandbox.zenodo.org/api. Sandbox doesnot work for
+    we can use sandbox for example, https://sandbox.zenodo.org/api. Sandbox does not work for
     reading."""
 
     title: Optional[str] = None

--- a/frictionless/resource/resource.py
+++ b/frictionless/resource/resource.py
@@ -222,7 +222,7 @@ class Resource(Metadata, metaclass=Factory):  # type: ignore
 
     tabular: ClassVar[bool] = False
     """
-    Whether the resoruce is tabular
+    Whether the resource is tabular
     """
 
     def __attrs_post_init__(self):
@@ -254,7 +254,7 @@ class Resource(Metadata, metaclass=Factory):  # type: ignore
 
         super().__attrs_post_init__()
 
-    # TODO: shall we guarantee here that it's at the beggining for the file?
+    # TODO: shall we guarantee here that it's at the beginning for the file?
     # TODO: maybe it's possible to do type narrowing here?
     def __enter__(self):
         if self.closed:
@@ -287,7 +287,7 @@ class Resource(Metadata, metaclass=Factory):  # type: ignore
         if self.path:
             return helpers.normalize_path(self.path, basepath=self.basepath)
 
-    # TODO: add asteriks for user/pass in url
+    # TODO: add asterisks for user/pass in url
     @property
     def place(self) -> str:
         """Stringified resource location"""
@@ -497,7 +497,7 @@ class Resource(Metadata, metaclass=Factory):  # type: ignore
             stats: stream file completely and infer stats
         """
         if not self.closed:
-            note = "Resource.infer canot be used on a open resource"
+            note = "Resource.infer cannot be used on a open resource"
             raise FrictionlessException(errors.ResourceError(note=note))
         with self:
             if not stats:
@@ -844,7 +844,7 @@ class Resource(Metadata, metaclass=Factory):  # type: ignore
         schema = descriptor.get("schema")
         if profile == "tabular-data-resource":
             if not schema:
-                note = 'profile "tabular-data-resource" requries "schema" to be present'
+                note = 'profile "tabular-data-resource" requires "schema" to be present'
                 yield errors.ResourceError(note=note)
 
         # Misleading

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -263,7 +263,7 @@ class TableResource(Resource):
 
     def __open_row_stream(self):
         # TODO: we need to rework this field_info / row code
-        # During row streaming we crate a field info structure
+        # During row streaming we create a field info structure
         # This structure is optimized and detached version of schema.fields
         # We create all data structures in-advance to share them between rows
 
@@ -461,7 +461,7 @@ class TableResource(Resource):
             stats: stream file completely and infer stats
         """
         if not self.closed:
-            note = "Resource.infer canot be used on a open resource"
+            note = "Resource.infer cannot be used on a open resource"
             raise FrictionlessException(errors.ResourceError(note=note))
         with self:
             if not stats:

--- a/frictionless/schemes/multipart/loader.py
+++ b/frictionless/schemes/multipart/loader.py
@@ -9,7 +9,7 @@ from ...system import Loader
 from .control import MultipartControl
 
 # NOTE:
-# Curretnly the situation with header/no-header concatenation is complicated
+# Currently the situation with header/no-header concatenation is complicated
 # We need to review it and add more tests for general/tabular edge cases
 
 

--- a/frictionless/steps/row/row_split.py
+++ b/frictionless/steps/row/row_split.py
@@ -28,7 +28,7 @@ class row_split(Step):
 
     field_name: str
     """
-    Field name whose cell value will be splitted.
+    Field name whose cell value will be split.
     """
 
     # Transform

--- a/frictionless/system/adapter.py
+++ b/frictionless/system/adapter.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 # NOTE:
 # There should be a way to check the supported functionality of a concrete adapter
-# For example, does it suport `read_catalog`? We can implement it based on what
+# For example, does it support `read_catalog`? We can implement it based on what
 # methods return (or not) or use some kins of `supported_actions` property
 
 

--- a/frictionless/system/loader.py
+++ b/frictionless/system/loader.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 # Probably we need to rework the way we calculate stats
 # First of all, it's not really reliable as read/read1(size) can be called many times
 # Secondly, for now, we stream compressed files twice (see loader.read_byte_stream_decompress)
-# Although, we need to reviw how we collect buffer - cab it be less IO operations?
+# Although, we need to review how we collect buffer - cab it be less IO operations?
 
 
 # TODO: migrate to dataclass?
@@ -209,7 +209,7 @@ class Loader:
             with platform.zipfile.ZipFile(byte_stream) as archive:
                 name = self.resource.innerpath or archive.namelist()[0]
                 if not name:
-                    error = errors.Error(note="the arhive is empty")
+                    error = errors.Error(note="the archive is empty")
                     raise FrictionlessException(error)
                 # TODO: enable typing when resource.innerpath is fixed
                 with archive.open(name) as file:  # type: ignore

--- a/frictionless/table/row.py
+++ b/frictionless/table/row.py
@@ -241,7 +241,7 @@ class Row(Dict[str, Any]):
         if types is None and csv:
             types = platform.frictionless_formats.CsvParser.supported_types
 
-        # Covert
+        # Convert
         if types is not None:
             for field_mapping in self.__field_info["mapping"].values():
                 field, _, _, cell_writer = field_mapping

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def duckdb_url_data(duckdb_url):
 def postgresql_url():
     url = os.environ.get("POSTGRESQL_URL")
     if not url:
-        pytest.skip('Environment varialbe "POSTGRESQL_URL" is not available')
+        pytest.skip('Environment variable "POSTGRESQL_URL" is not available')
     yield url
     engine = sa.create_engine(url)
     with engine.begin() as conn:
@@ -71,7 +71,7 @@ def postgresql_url_data(postgresql_url):
 def mysql_url():
     url = os.environ.get("MYSQL_URL")
     if not url:
-        pytest.skip('Environment varialbe "MYSQL_URL" is not available')
+        pytest.skip('Environment variable "MYSQL_URL" is not available')
     yield url
     engine = sa.create_engine(url)
     with engine.begin() as conn:

--- a/tests/console/commands/test_validate.py
+++ b/tests/console/commands/test_validate.py
@@ -247,7 +247,7 @@ def test_console_validate_enforce_required_fields_only_for_data_using_schema_syn
     output = json.loads(actual.stdout)
     expect = [error for error in output["tasks"][0]["errors"]]
     # using schema-sync to skip type-error due to positional matching of
-    # fields and data, incase any field data is missing
+    # fields and data, in case any field data is missing
     assert "type-error" not in expect
     assert "incorrect-label" not in expect
 

--- a/tests/formats/spss/test_parser.py
+++ b/tests/formats/spss/test_parser.py
@@ -51,7 +51,7 @@ def test_spss_parser_write_types(tmpdir):
             ],
         }
 
-        # Asssert rows
+        # Assert rows
         assert target.read_rows() == [
             {
                 "any": "中国人",
@@ -91,7 +91,7 @@ def test_spss_storage_constraints(tmpdir):
             ],
         }
 
-        # Asssert rows
+        # Assert rows
         assert target.read_rows() == [
             {
                 "required": "passing",

--- a/tests/formats/sql/databases/duckdb/test_parser.py
+++ b/tests/formats/sql/databases/duckdb/test_parser.py
@@ -22,7 +22,7 @@ def test_sql_parser(duckdb_url_data):
                 {"name": "id", "type": "integer", "constraints": {"required": True}},
                 {"name": "name", "type": "string"},
             ],
-            # TODO: add indicies support
+            # TODO: add indices support
             # DuckDBEngineWarning: duckdb-engine doesn't yet support reflection on indices
             # https://github.com/Mause/duckdb_engine/blob/71b1ed2f63dc25a848995986401be765711d763d/duckdb_engine/__init__.py#L159
             #  "primaryKey": ["id"],

--- a/tests/indexer/test_resource.py
+++ b/tests/indexer/test_resource.py
@@ -53,7 +53,7 @@ def test_resource_index_sqlite_with_metadata(database_url):
 # Fast
 
 
-@pytest.mark.ci(reason="requries sqlite3@3.34+")
+@pytest.mark.ci(reason="requires sqlite3@3.34+")
 @pytest.mark.parametrize("database_url", fast_database_urls)
 def test_resource_index_sqlite_fast(database_url):
     assert control.table
@@ -68,7 +68,7 @@ def test_resource_index_sqlite_fast(database_url):
 # Fallback
 
 
-@pytest.mark.ci(reason="requries sqlite3@3.34+")
+@pytest.mark.ci(reason="requires sqlite3@3.34+")
 @pytest.mark.parametrize("database_url", fast_database_urls)
 def test_resource_index_sqlite_fast_with_use_fallback(database_url):
     assert control.table

--- a/tests/package/test_profile.py
+++ b/tests/package/test_profile.py
@@ -146,7 +146,7 @@ def test_package_profile_tabular_requirements_issue_1484():
     assert report.flatten(["type", "note"]) == [
         [
             "package-error",
-            'profile "tabular-data-package" requries all the resources to be "tabular-data-resource"',
+            'profile "tabular-data-package" requires all the resources to be "tabular-data-resource"',
         ]
     ]
 
@@ -169,6 +169,6 @@ def test_package_profile_tabular_requirements_schema_issue_1484():
     assert report.flatten(["type", "note"]) == [
         [
             "resource-error",
-            'profile "tabular-data-resource" requries "schema" to be present',
+            'profile "tabular-data-resource" requires "schema" to be present',
         ]
     ]

--- a/tests/validator/resource/test_general.py
+++ b/tests/validator/resource/test_general.py
@@ -313,7 +313,7 @@ def test_resource_validate_infer_fields_issue_225():
 
 
 def test_resource_validate_fails_with_wrong_encoding_issue_274():
-    # For now, by default encoding is detected incorectly by chardet
+    # For now, by default encoding is detected incorrectly by chardet
     resource = TableResource(path="data/encoding-issue-274.csv", encoding="utf-8")
     report = resource.validate()
     assert report.valid


### PR DESCRIPTION
This PR fixes some minor typos, no issue created, because this should be trivial.

These changes were done with codespell.

It also wanted to replace "underlaying" -> "underlying". Which I ignored. That is correct, right?