### PR TITLE
Fix 1628 unexpected schema error with schema name containing upper case letter

### DIFF
--- a/data/schema_with_uppercase_name.json
+++ b/data/schema_with_uppercase_name.json
@@ -1,0 +1,13 @@
+{
+    "name": "Uppercase",
+    "fields": [
+        {
+            "name": "id",
+            "type": "integer"
+        },
+        {
+            "name": "name",
+            "type": "string"
+        }
+    ]
+}

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -287,7 +287,7 @@ class Schema(Metadata, metaclass=Factory):
         "type": "object",
         "required": ["fields"],
         "properties": {
-            "name": {"type": "string", "pattern": settings.NAME_PATTERN},
+            "name": {"type": "string", "pattern": settings.INSENTIVE_CASE_NAME_PATTERN},
             "type": {"type": "string", "pattern": settings.TYPE_PATTERN},
             "title": {"type": "string"},
             "description": {"type": "string"},

--- a/frictionless/settings.py
+++ b/frictionless/settings.py
@@ -11,6 +11,7 @@ VERSION = "5.16.1"
 
 UNDEFINED = object()
 NAME_PATTERN = "^([-a-z0-9._/])+$"
+INSENTIVE_CASE_NAME_PATTERN = "^([-a-zA-Z0-9._/])+$"
 TYPE_PATTERN = "^([-a-z/])+$"
 PACKAGE_PATH = "datapackage.json"
 COMPRESSION_FORMATS = ["zip", "gz", "bz2", "xz"]

--- a/tests/schema/test_validate.py
+++ b/tests/schema/test_validate.py
@@ -8,6 +8,11 @@ def test_validate():
     assert report.valid
 
 
+def test_validate_insensitive_case_schema_name_issue_1628():
+    report = Schema.validate_descriptor("data/schema_with_uppercase_name.json")
+    assert report.valid
+
+
 def test_validate_invalid():
     report = Schema.validate_descriptor({"fields": "bad"})
     assert report.flatten(["type", "note"]) == [


### PR DESCRIPTION
- fixes #1628 

---
This PR fixes the `schema-error` which occurs doing `frictionless validate data.csv --schema schema.json` with a `TableSchema` `schema` name containing an upper-case letter, for example:

```
schema.json
-----
{
    "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
    "name": "Uppercase",
    "fields": [
        {"name": "A", "title": "Field A", "type": "string"},
        {"name": "B", "title": "Field B", "type": "string"}
    ]
}
```
```
data.csv
----
A, B
a, b
```
This PR adds a test case to ensure that the validation of a schema containing an upper-case letter in its name does not generate a `schema-error` related to this upper-case- letter.
