### PR TITLE
1631: Pin black, moto, pytest versions to avoid breaking changes to tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,15 +58,15 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "moto",
+    "moto>=4.2.14,<5.0.0",
     "ruff",
     "httpx",
     "hatch",
     "isort",
-    "black",
+    "black>=23.12.1,<24.0.0",
     "yattag",
     "neovim",
-    "pytest",
+    "pytest>=7.4.4,<8.0.0",
     "pyright==1.1.317",
     "ipython",
     "livemark",


### PR DESCRIPTION
# Summary

- fixes #1631

Over the weekend (26-27 Jan 2024) there were major updates to black, moto, and pytest that broke the tests.  This commit pins the versions of those tools to before their major updates to get the automated running & passing again.

Actual updates to the code to be in line with the latest versions can follow in a later PR.

# Tests

Run `hatch -e ci.py3.10 run test` and ensure all tests run and pass (with test db images up and running).

