### PR TITLE
Fix 1635 unexpected missing label error when ignoring header case

### DIFF
--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -483,6 +483,7 @@ class Detector:
         case_sensitive: bool,
     ):
         for _, field in fields_map.items():
+            #TODO use self.field_name_not_in_labels
             if case_sensitive:
                 if field and field.required and field.name not in labels:
                     schema.add_field(field)
@@ -493,3 +494,20 @@ class Detector:
                     and field.name.lower() not in [label.lower() for label in labels]
                 ):
                     schema.add_field(field)
+
+    @staticmethod
+    def field_name_not_in_labels(
+        field: Field,
+        labels: List[str],
+        case_sensitive: bool
+    ) -> bool:
+        if case_sensitive:
+            return field and field.required and field.name not in labels
+        else:
+            return (
+                    field
+                    and field.required
+                    and field.name.lower() not in [
+                        label.lower() for label in labels
+                        ]
+            )

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -298,7 +298,7 @@ class Detector:
         labels: Optional[List[str]] = None,
         schema: Optional[Schema] = None,
         field_candidates: List[Dict[str, Any]] = settings.DEFAULT_FIELD_CANDIDATES,
-        **options: Any
+        **options: Any,
     ) -> Schema:
         """Detect schema from fragment
 
@@ -412,7 +412,7 @@ class Detector:
                 if options["header_case"]:
                     mapping = {field.name: field for field in schema.fields}  # type: ignore
                 else:
-                    mapping = {field.name.lower(): field for field in schema.fields} # type: ignore
+                    mapping = {field.name.lower(): field for field in schema.fields}  # type: ignore
                 schema.clear_fields()
                 for name in labels:
                     if options["header_case"]:
@@ -428,8 +428,12 @@ class Detector:
                         if field and field.required and field.name not in labels:
                             schema.add_field(field)
                     else:
-                        if field and field.required and field.name.lower() not in [
-                            label.lower() for label in labels]:
+                        if (
+                            field
+                            and field.required
+                            and field.name.lower()
+                            not in [label.lower() for label in labels]
+                        ):
                             schema.add_field(field)
 
         # Patch schema

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -495,10 +495,9 @@ class Detector:
         field: Field, labels: List[str], case_sensitive: bool
     ) -> bool:
         if case_sensitive:
-            return field and field.required and field.name not in labels
+            return field.required and field.name not in labels
         else:
             return (
-                field
-                and field.required
+                field.required
                 and field.name.lower() not in [label.lower() for label in labels]
             )

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -453,7 +453,7 @@ class Detector:
         Args:
             fields (Union[List[None], List[Field]]): list of original
                                                         schema fields
-            case_sensitive (bool)
+            case_sensitive (bool): True if case sensitive, False else
 
         Returns:
             Dict[str, Optional[Field]]

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -389,13 +389,21 @@ class TableResource(Resource):
 
         # NB: missing required labels are not included in the
         # field_info parameter used for row creation
-        if self.detector.schema_sync and self.dialect.header_case:
+        if self.detector.schema_sync:
             for field in self.schema.fields:
-                if field.name not in self.labels and field.name in field_info["names"]:
-                    field_index = field_info["names"].index(field.name)
-                    del field_info["names"][field_index]
-                    del field_info["objects"][field_index]
-                    del field_info["mapping"][field.name]
+                if self.dialect.header_case:
+                    if field.name not in self.labels and field.name in field_info["names"]:
+                        field_index = field_info["names"].index(field.name)
+                        del field_info["names"][field_index]
+                        del field_info["objects"][field_index]
+                        del field_info["mapping"][field.name]
+                else:  # Ignore case
+                    if field.name.lower() not in [label.lower() for label in self.labels] \
+                            and field.name.lower() in [field_info_name.lower() for field_info_name in field_info["names"]]:
+                        field_index = field_info["names"].index(field.name)
+                        del field_info["names"][field_index]
+                        del field_info["objects"][field_index]
+                        del field_info["mapping"][field.name]
 
         # Create row stream
         self.__row_stream = row_stream()

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -204,6 +204,7 @@ class TableResource(Resource):
             labels=self.labels,
             schema=self.schema,
             field_candidates=system.detect_field_candidates(),
+            header_case=self.dialect.header_case
         )
         self.stats.fields = len(self.schema.fields)
 
@@ -388,14 +389,15 @@ class TableResource(Resource):
 
         # NB: missing required labels are not included in the
         # field_info parameter used for row creation
-        if self.detector.schema_sync:
+        if self.detector.schema_sync and self.dialect.header_case:
             for field in self.schema.fields:
                 if field.name not in self.labels and field.name in field_info["names"]:
                     field_index = field_info["names"].index(field.name)
                     del field_info["names"][field_index]
                     del field_info["objects"][field_index]
                     del field_info["mapping"][field.name]
-        # # Create row stream
+
+        # Create row stream
         self.__row_stream = row_stream()
 
     # Read

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -392,14 +392,20 @@ class TableResource(Resource):
         if self.detector.schema_sync:
             for field in self.schema.fields:
                 if self.dialect.header_case:
-                    if field.name not in self.labels and field.name in field_info["names"]:
+                    if (
+                        field.name not in self.labels
+                        and field.name in field_info["names"]
+                    ):
                         field_index = field_info["names"].index(field.name)
                         del field_info["names"][field_index]
                         del field_info["objects"][field_index]
                         del field_info["mapping"][field.name]
                 else:  # Ignore case
-                    if field.name.lower() not in [label.lower() for label in self.labels] \
-                            and field.name.lower() in [field_info_name.lower() for field_info_name in field_info["names"]]:
+                    if field.name.lower() not in [
+                        label.lower() for label in self.labels
+                    ] and field.name.lower() in [
+                        field_info_name.lower() for field_info_name in field_info["names"]
+                    ]:
                         field_index = field_info["names"].index(field.name)
                         del field_info["names"][field_index]
                         del field_info["objects"][field_index]

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -204,7 +204,7 @@ class TableResource(Resource):
             labels=self.labels,
             schema=self.schema,
             field_candidates=system.detect_field_candidates(),
-            header_case=self.dialect.header_case
+            header_case=self.dialect.header_case,
         )
         self.stats.fields = len(self.schema.fields)
 

--- a/tests/validator/resource/test_schema.py
+++ b/tests/validator/resource/test_schema.py
@@ -378,10 +378,10 @@ def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_16
     schema_descriptor_3 = {
         "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
         "fields": [
-                {"name": "Aa", "constraints": {"required": True}},
-                {"name": "BB", "constraints": {"required": True}},
-                {"name": "cc"}
-            ]
+            {"name": "Aa", "constraints": {"required": True}},
+            {"name": "BB", "constraints": {"required": True}},
+            {"name": "cc"},
+        ],
     }
     schema = Schema.from_descriptor(schema_descriptor_3)
     source = [["bb", "CC"], ["foo", "bar"]]
@@ -389,7 +389,7 @@ def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_16
         source,
         schema=schema,
         detector=Detector(schema_sync=True),
-        dialect=Dialect(header_case=False)
+        dialect=Dialect(header_case=False),
     )
     assert not report.valid
     # Expect one single error misisng-label related to missing column 'Aa'

--- a/tests/validator/resource/test_schema.py
+++ b/tests/validator/resource/test_schema.py
@@ -391,31 +391,30 @@ def test_validate_resource_ignoring_header_case_issue_1635():
                 "type": "string",
                 "constraints": {"required": True},
             },
-            {"name": "CC", "title": "Field C", "type": "string"},
         ],
     }
 
     test_cases = [
         {
-            "source": [["AA", "bb", "cc"], ["a", "b", "c"]],
-            "dialect": Dialect(header_case=False),
+            "source": [["AA", "bb"], ["a", "b"]],
+            "header_case": False,
             "expected_valid_report": True,
             "expected_flattened_report": [],
         },
         {
-            "source": [["AA", "bb", "cc"], ["a", "b", "c"]],
-            "dialect": Dialect(header_case=True),
+            "source": [["AA", "bb"], ["a", "b"]],
+            "header_case": True,
             "expected_valid_report": False,
             "expected_flattened_report": [
-                [None, 4, "aa", "missing-label"],
-                [None, 5, "BB", "missing-label"],
+                [None, 3, "aa", "missing-label"],
+                [None, 4, "BB", "missing-label"],
             ],
         },
         {
-            "source": [["bb", "CC"], ["foo", "bar"]],
-            "dialect": Dialect(header_case=False),
+            "source": [["bb"], ["foo"]],
+            "header_case": False,
             "expected_valid_report": False,
-            "expected_flattened_report": [[None, 3, "aa", "missing-label"]],
+            "expected_flattened_report": [[None, 2, "aa", "missing-label"]],
         },
     ]
 
@@ -424,7 +423,7 @@ def test_validate_resource_ignoring_header_case_issue_1635():
             tc["source"],
             schema=Schema.from_descriptor(schema_descriptor),
             detector=Detector(schema_sync=True),
-            dialect=tc["dialect"],
+            dialect=Dialect(header_case=tc["header_case"]),
         )
         report = frictionless.validate(resource)
         assert report.valid == tc["expected_valid_report"]

--- a/tests/validator/resource/test_schema.py
+++ b/tests/validator/resource/test_schema.py
@@ -369,11 +369,33 @@ def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_16
             tc["source"], schema=schema, detector=Detector(schema_sync=True)
         )
         report = frictionless.validate(resource)
-        print(report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"]))
         assert (
             report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])
             == tc["expected_flattened_report"]
         )
+
+    # Ignore case
+    schema_descriptor_3 = {
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [
+                {"name": "Aa", "constraints": {"required": True}},
+                {"name": "BB", "constraints": {"required": True}},
+                {"name": "cc"}
+            ]
+    }
+    schema = Schema.from_descriptor(schema_descriptor_3)
+    source = [["bb", "CC"], ["foo", "bar"]]
+    report = frictionless.validate(
+        source,
+        schema=schema,
+        detector=Detector(schema_sync=True),
+        dialect=Dialect(header_case=False)
+    )
+    assert not report.valid
+    # Expect one single error misisng-label related to missing column 'Aa'
+    assert (report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])) == [
+        [None, 3, "Aa", "missing-label"]
+    ]
 
 
 def test_validate_resource_ignoring_header_case_issue_1635():

--- a/tests/validator/resource/test_schema.py
+++ b/tests/validator/resource/test_schema.py
@@ -392,18 +392,23 @@ def test_validate_resource_ignoring_header_case_issue_1635():
     }
 
     source = [["aa", "bb", "cc"], ["a", "b", "c"]]
+
+    schema = Schema.from_descriptor(schema_descriptor)
+    
+    detector = Detector(schema_sync=True)
+
     report = frictionless.validate(
-        source=source,
-        schema=Schema.from_descriptor(schema_descriptor),
-        detector=Detector(schema_sync=True),
+        source,
+        schema=schema,
+        detector=detector,
         dialect=Dialect(header_case=False)
     )
     assert report.valid
 
     report = frictionless.validate(
-        source=source,
-        schema=Schema.from_descriptor(schema_descriptor),
-        detector=Detector(schema_sync=True)
+        source,
+        schema=schema,
+        detector=detector,
     )
     assert not report.valid
     assert (report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])) == [[None, 4, "AA", "missing-label"]]

--- a/tests/validator/resource/test_schema.py
+++ b/tests/validator/resource/test_schema.py
@@ -3,8 +3,8 @@ from copy import deepcopy
 import pytest
 
 import frictionless
-from frictionless import Checklist, Detector, FrictionlessException, Schema, fields
-from frictionless import Dialect
+from frictionless import Checklist, Detector, Dialect, FrictionlessException, Schema
+from frictionless import fields
 from frictionless.resources import TableResource
 
 # General
@@ -394,14 +394,11 @@ def test_validate_resource_ignoring_header_case_issue_1635():
     source = [["aa", "bb", "cc"], ["a", "b", "c"]]
 
     schema = Schema.from_descriptor(schema_descriptor)
-    
+
     detector = Detector(schema_sync=True)
 
     report = frictionless.validate(
-        source,
-        schema=schema,
-        detector=detector,
-        dialect=Dialect(header_case=False)
+        source, schema=schema, detector=detector, dialect=Dialect(header_case=False)
     )
     assert report.valid
 
@@ -411,4 +408,6 @@ def test_validate_resource_ignoring_header_case_issue_1635():
         detector=detector,
     )
     assert not report.valid
-    assert (report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])) == [[None, 4, "AA", "missing-label"]]
+    assert (report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])) == [
+        [None, 4, "AA", "missing-label"]
+    ]


### PR DESCRIPTION
- fixes #1635 

---
This PR fixes unexpected `missing-label` error in validation report which occurs when validating tabular data in this specific case: The data contains a named column corresponding to a required fieldin the schema used for validation, written without respecting case-sensitivity.
For example:
```
data = [["aa", "BB"], ["a", "b"]]
schema = {
        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
        "fields": [
            {"name": "AA", "constraints": {"required": True}},
            {"name": "bb", "constraints": {"required": True}}
        ]
    }
```
This PR adds some test cases: 
- one test case to ensure that validating this tabular data with this schema and using `schema_sync=True` and `dialect=Dialect(header_case=False)` options, returns a valid report.
- one test case to ensure that if validation is case-sensitive, if a name column does not respect case a missing-label occurs in validation report.
- another test case to ensure that validating with missing required column "AA" with this schema and using `schema_sync=True` and `dialect=Dialect(header_case=False)` options, returns an invalid report with `missing-label` error related to field "AA".

Finally, I suggest some refactoring in this PR:
- refactoring removing missing required label from field info refactoring removing missing required label from field info
- refactoring creating schema fields among labels part when using `schema_sync` option in `detect_schema()` `Detector` method




