### PR TITLE
WIP : Fix 1633 unexpected key error with primary key in schema

### DIFF
--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -419,6 +419,9 @@ class Detector:
                 for _, field in mapping.items():
                     if field and field.required and field.name not in labels:
                         schema.add_field(field)
+                    # For primary field that are missing
+                    if field and not field.required and field.name in schema.primary_key and field.name not in labels:
+                        schema.add_field(field)
 
         # Patch schema
         if self.schema_patch:

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -439,26 +439,39 @@ class Detector:
 
         return schema  # type: ignore
 
-    @staticmethod
     def add_missing_primary_key_to_schema_fields(
+        self,
         field: Field,
         schema: Schema,
         labels: List[str],
         case_sensitive: bool,
     ):
+        if self.primary_key_field_not_in_labels(
+            field,
+            schema,
+            labels,
+            case_sensitive,
+        ):
+            schema.add_field(field)
+
+    @staticmethod
+    def primary_key_field_not_in_labels(
+        field: Field,
+        schema: Schema,
+        labels: List[str],
+        case_sensitive: bool,
+    ) -> bool:
         if case_sensitive:
-            if (
+            return (
                 not field.required
                 and field.name in schema.primary_key
                 and field.name not in labels
-            ):
-                schema.add_field(field)
+            )
         else:
             lower_primary_key = [pk.lower() for pk in schema.primary_key]
             lower_labels = [label.lower() for label in labels]
-            if (
+            return (
                 not field.required
                 and field.name.lower() in lower_primary_key
                 and field.name.lower() not in lower_labels
-            ):
-                schema.add_field(field)
+            )

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -335,7 +335,12 @@ class TableResource(Resource):
                         cells = tuple(row[name] for name in self.schema.primary_key)
                     except KeyError:
                         # Row does not have primary_key as key
-                        pass
+                        # There is a missing label corresponding to the schema
+                        note = (
+                            f"Inexistant label for primary key {self.schema.primary_key}"
+                        )
+                        error = errors.PrimaryKeyError.from_row(row, note=note)
+                        row.errors.append(error)
                     else:
                         if set(cells) == {None}:
                             note = 'cells composing the primary keys are all "None"'
@@ -347,7 +352,9 @@ class TableResource(Resource):
                             if match:
                                 if match:
                                     note = "the same as in the row at position %s" % match
-                                    error = errors.PrimaryKeyError.from_row(row, note=note)
+                                    error = errors.PrimaryKeyError.from_row(
+                                        row, note=note
+                                    )
                                     row.errors.append(error)
 
                 # Foreign Key Error

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -413,18 +413,29 @@ class TableResource(Resource):
         self,
         row: Row,
         case_sensitive: bool
-    ) -> Tuple[Row, Any]:
+    ) -> Tuple[str, Any]:
         """Create a tuple containg all cells related to primary_key
         """
+        return tuple(row[label] for label in
+                     self.labels_related_to_primary_key(row, case_sensitive))
+    
+    def labels_related_to_primary_key(
+        self,
+        row: Row,
+        case_sensitive: bool,
+    ) -> List[str]:
+        """Create a list of TabelResource labels which correspond to the
+        primary_key schema considering case-sensitivity
+        """
         if case_sensitive:
-            cells = tuple(row[name] for name in self.schema.primary_key)
-        else:  # Ignore case
-            lower_primary_keys = [
+            labels_primary_key = self.schema.primary_key
+        else:
+            lower_primary_key = [
                 pk.lower() for pk in self.schema.primary_key
             ]
-            labels_primary_key = [label for label in row.field_names if label.lower() in lower_primary_keys]
-            cells = tuple(row[label] for label in labels_primary_key)
-        return cells
+            labels_primary_key = [label for label in row.field_names
+                                  if label.lower() in lower_primary_key]
+        return labels_primary_key
 
     # Read
     def read_cells(self, *, size: Optional[int] = None) -> List[List[Any]]:

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -334,29 +334,28 @@ class TableResource(Resource):
                     try:
                         if self.dialect.header_case:
                             cells = tuple(row[name] for name in self.schema.primary_key)
-                        else:  # ignore case
+                        else:  # Ignore case
                             cells = ()
-                            lower_primary_keys = [pk.lower() for pk in self.schema.primary_key]
+                            lower_primary_keys = [
+                                pk.lower() for pk in self.schema.primary_key
+                            ]
                             # cells = tuple(row[label] if (label.lower() for label in row.field_names) in lower_primary_keys )
                             for label in row.field_names:
                                 if label.lower() in lower_primary_keys:
                                     cells = cells + (row[label],)
                     except KeyError:
                         # Row does not have primary_key as key
-                        # There is a missing label corresponding to the schema
-                        note = (
-                            f"Inexistant label for primary key {self.schema.primary_key}"
-                        )
-                        error = errors.PrimaryKeyError.from_row(row, note=note)
-                        row.errors.append(error)
+                        # There should already be a missing-label error in
+                        # in self.header corresponding to the schema primary key
+                        assert not self.header.valid
                     else:
                         if set(cells) == {None}:
                             note = 'cells composing the primary keys are all "None"'
                             error = errors.PrimaryKeyError.from_row(row, note=note)
                             row.errors.append(error)
                         else:
-                            match = memory_primary.get(cells)
-                            memory_primary[cells] = row.row_number
+                            match = memory_primary.get(cells)  # type: ignore
+                            memory_primary[cells] = row.row_number  # type: ignore
                             if match:
                                 if match:
                                     note = "the same as in the row at position %s" % match

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -331,19 +331,24 @@ class TableResource(Resource):
 
                 # Primary Key Error
                 if is_integrity and self.schema.primary_key:
-                    cells = tuple(row[name] for name in self.schema.primary_key)
-                    if set(cells) == {None}:
-                        note = 'cells composing the primary keys are all "None"'
-                        error = errors.PrimaryKeyError.from_row(row, note=note)
-                        row.errors.append(error)
+                    try:
+                        cells = tuple(row[name] for name in self.schema.primary_key)
+                    except KeyError:
+                        # Row does not have primary_key as key
+                        pass
                     else:
-                        match = memory_primary.get(cells)
-                        memory_primary[cells] = row.row_number
-                        if match:
+                        if set(cells) == {None}:
+                            note = 'cells composing the primary keys are all "None"'
+                            error = errors.PrimaryKeyError.from_row(row, note=note)
+                            row.errors.append(error)
+                        else:
+                            match = memory_primary.get(cells)
+                            memory_primary[cells] = row.row_number
                             if match:
-                                note = "the same as in the row at position %s" % match
-                                error = errors.PrimaryKeyError.from_row(row, note=note)
-                                row.errors.append(error)
+                                if match:
+                                    note = "the same as in the row at position %s" % match
+                                    error = errors.PrimaryKeyError.from_row(row, note=note)
+                                    row.errors.append(error)
 
                 # Foreign Key Error
                 if is_integrity and foreign_groups:

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -332,7 +332,11 @@ class TableResource(Resource):
                 # Primary Key Error
                 if is_integrity and self.schema.primary_key:
                     try:
-                        cells = tuple(row[name] for name in self.schema.primary_key)
+                        if self.dialect.header_case:
+                            cells = tuple(row[name] for name in self.schema.primary_key)
+                        else: # ignore case
+                            primary_key_lowers = [pk.lower() for pk in self.schema.primary_key]
+                            cells = tuple(row[name] for name in primary_key_lowers)
                     except KeyError:
                         # Row does not have primary_key as key
                         # There is a missing label corresponding to the schema

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -419,14 +419,11 @@ class TableResource(Resource):
         if case_sensitive:
             cells = tuple(row[name] for name in self.schema.primary_key)
         else:  # Ignore case
-            cells = ()
             lower_primary_keys = [
                 pk.lower() for pk in self.schema.primary_key
             ]
-            # cells = tuple(row[label] if (label.lower() for label in row.field_names) in lower_primary_keys )
-            for label in row.field_names:
-                if label.lower() in lower_primary_keys:
-                    cells = cells + (row[label],)
+            labels_primary_key = [label for label in row.field_names if label.lower() in lower_primary_keys]
+            cells = tuple(row[label] for label in labels_primary_key)
         return cells
 
     # Read

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -334,9 +334,13 @@ class TableResource(Resource):
                     try:
                         if self.dialect.header_case:
                             cells = tuple(row[name] for name in self.schema.primary_key)
-                        else: # ignore case
-                            primary_key_lowers = [pk.lower() for pk in self.schema.primary_key]
-                            cells = tuple(row[name] for name in primary_key_lowers)
+                        else:  # ignore case
+                            cells = ()
+                            lower_primary_keys = [pk.lower() for pk in self.schema.primary_key]
+                            # cells = tuple(row[label] if (label.lower() for label in row.field_names) in lower_primary_keys )
+                            for label in row.field_names:
+                                if label.lower() in lower_primary_keys:
+                                    cells = cells + (row[label],)
                     except KeyError:
                         # Row does not have primary_key as key
                         # There is a missing label corresponding to the schema

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -47,11 +47,11 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
             "nb_errors": 1,
             "types_errors_expected": ["missing-label"],
         },
-        # { # This test case raise the unexpected KeyError we want to fix
-        #     "constraints": {},
-        #     "nb_errors": 1,
-        #     "types_errors_expected": ["missing-label"],
-        # },
+        {
+            "constraints": {},
+            "nb_errors": 1,
+            "types_errors_expected": ["missing-label"],
+        },
     ]
 
     for tc in test_cases:
@@ -74,24 +74,6 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
         assert len(errors) == tc["nb_errors"]
         for error, type_expected in zip(errors, tc["types_errors_expected"]):
             assert error.type == type_expected
-
-    # TODO: fix this isolated test case and refactoring
-    schema_descriptor = {
-            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-            "fields": [{"name": "A"}],
-            "primaryKey": ["A"],
-        }
-
-    resource = TableResource(
-            source=[["B"], ["foo"]],
-            schema=Schema.from_descriptor(schema_descriptor),
-            detector=frictionless.Detector(schema_sync=True),
-        )
-
-    report = frictionless.validate(resource)
-    errors = report.tasks[0].errors
-    assert len(errors) == 1
-    assert errors[0].type == "missing-label"
 
     # # Ignore header_case
     # schema_descriptor = {

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -78,7 +78,7 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
     # Ignore header_case
     schema_descriptor = {
         "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-        "fields": [{"name": "A", "constraints": {"required": True}}],
+        "fields": [{"name": "A"}],
         "primaryKey": ["A"],
     }
 

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -47,11 +47,11 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
             "nb_errors": 1,
             "types_errors_expected": ["missing-label"],
         },
-        {
-            "constraints": {},
-            "nb_errors": 1,
-            "types_errors_expected": ["missing-label"],
-        },
+        # { # This test case raise the unexpected KeyError we want to fix
+        #     "constraints": {},
+        #     "nb_errors": 1,
+        #     "types_errors_expected": ["missing-label"],
+        # },
     ]
 
     for tc in test_cases:
@@ -74,6 +74,24 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
         assert len(errors) == tc["nb_errors"]
         for error, type_expected in zip(errors, tc["types_errors_expected"]):
             assert error.type == type_expected
+
+    # TODO: fix this isolated test case and refactoring
+    schema_descriptor = {
+            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+            "fields": [{"name": "A"}],
+            "primaryKey": ["A"],
+        }
+
+    resource = TableResource(
+            source=[["B"], ["foo"]],
+            schema=Schema.from_descriptor(schema_descriptor),
+            detector=frictionless.Detector(schema_sync=True),
+        )
+
+    report = frictionless.validate(resource)
+    errors = report.tasks[0].errors
+    assert len(errors) == 1
+    assert errors[0].type == "missing-label"
 
     # Ignore header_case
     schema_descriptor = {

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -57,10 +57,11 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
 
     report = frictionless.validate(resource)
 
-    assert len(report.tasks[0].errors) == 1
-    assert report.tasks[0].errors[0].type == "missing-label"
     assert not report.valid
-
+    assert len(report.tasks[0].errors) == 2
+    assert report.tasks[0].errors[0].type == "missing-label"
+    assert report.tasks[0].errors[1].type == "primary-key"
+    
     schema_descriptor = {
         "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
         "fields": [{"name": "A"}],
@@ -76,6 +77,6 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
     )
 
     report = frictionless.validate(resource)
-    print(report)
-    assert report.tasks[0].errors[0].type == "primary-key"
     assert not report.valid
+    assert len(report.tasks[0].errors) == 1
+    assert report.tasks[0].errors[0].type == "primary-key"

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -75,3 +75,19 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
         assert len(errors) == tc["nb_errors"]
         for error, type_expected in zip(errors, tc["types_errors_expected"]):
             assert error.type == type_expected
+
+    # Ignore header_case
+    schema_descriptor = {
+            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+            "fields": [{"name": "A"}],
+            "primaryKey": ["A"],
+        }
+
+    resource = TableResource(
+        source=[["a"], ["foo"]],
+        schema=Schema.from_descriptor(schema_descriptor),
+        detector=frictionless.Detector(schema_sync=True),
+        dialect=frictionless.Dialect(header_case=False)
+    )
+    report = frictionless.validate(resource)
+    assert report.valid

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -93,18 +93,18 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
     assert len(errors) == 1
     assert errors[0].type == "missing-label"
 
-    # Ignore header_case
-    schema_descriptor = {
-        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-        "fields": [{"name": "A"}],
-        "primaryKey": ["A"],
-    }
+    # # Ignore header_case
+    # schema_descriptor = {
+    #     "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+    #     "fields": [{"name": "A", "constraints": {"required": True}}],
+    #     "primaryKey": ["A"],
+    # }
 
-    resource = TableResource(
-        source=[["a"], ["foo"]],
-        schema=Schema.from_descriptor(schema_descriptor),
-        detector=frictionless.Detector(schema_sync=True),
-        dialect=frictionless.Dialect(header_case=False),
-    )
-    report = frictionless.validate(resource)
-    assert report.valid
+    # resource = TableResource(
+    #     source=[["a"], ["foo"]],
+    #     schema=Schema.from_descriptor(schema_descriptor),
+    #     detector=frictionless.Detector(schema_sync=True),
+    #     dialect=frictionless.Dialect(header_case=False),
+    # )
+    # report = frictionless.validate(resource)
+    # assert report.valid

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -47,11 +47,11 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
             "nb_errors": 1,
             "types_errors_expected": ["missing-label"],
         },
-        # {
-        #     "constraints": {},
-        #     "nb_errors": 1,
-        #     "types_errors_expected": ["missing-label"],
-        # },
+        {
+            "constraints": {},
+            "nb_errors": 1,
+            "types_errors_expected": ["missing-label"],
+        },
     ]
 
     for tc in test_cases:

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -60,3 +60,22 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
     assert len(report.tasks[0].errors) == 1
     assert report.tasks[0].errors[0].type == "missing-label"
     assert not report.valid
+
+    schema_descriptor = {
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [{"name": "A"}],
+        "primaryKey": ["A"],
+    }
+
+    source = [["B"], ["foo"]]
+
+    resource = TableResource(
+        source,
+        schema=Schema.from_descriptor(schema_descriptor),
+        detector=frictionless.Detector(schema_sync=True),
+    )
+
+    report = frictionless.validate(resource)
+    print(report)
+    assert report.tasks[0].errors[0].type == "primary-key"
+    assert not report.valid

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -90,3 +90,19 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
     )
     report = frictionless.validate(resource)
     assert report.valid
+    
+    # TODO to solve this test case needs to merge with working branch Fix-1635-...
+    schema_descriptor = {
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [{"name": "A", "constraints": {"required": True}}],
+        "primaryKey": ["A"],
+    }
+
+    resource = TableResource(
+        source=[["a"], ["foo"]],
+        schema=Schema.from_descriptor(schema_descriptor),
+        detector=frictionless.Detector(schema_sync=True),
+        dialect=frictionless.Dialect(header_case=False),
+    )
+    report = frictionless.validate(resource)
+    assert report.valid

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -41,18 +41,17 @@ def test_missing_label():
 
 
 def test_missing_primary_key_label_with_shema_sync_issue_1633():
-
     test_cases = [
         {
             "constraints": {"required": True},
-            "nb_errors": 2,
-            "types_errors_expected": ["missing-label", "primary-key"],
-        },
-        {
-            "constraints": {},
             "nb_errors": 1,
-            "types_errors_expected": ["primary-key"],
-        }
+            "types_errors_expected": ["missing-label"],
+        },
+        # {
+        #     "constraints": {},
+        #     "nb_errors": 1,
+        #     "types_errors_expected": ["missing-label"],
+        # },
     ]
 
     for tc in test_cases:
@@ -78,16 +77,16 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
 
     # Ignore header_case
     schema_descriptor = {
-            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-            "fields": [{"name": "A"}],
-            "primaryKey": ["A"],
-        }
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [{"name": "A"}],
+        "primaryKey": ["A"],
+    }
 
     resource = TableResource(
         source=[["a"], ["foo"]],
         schema=Schema.from_descriptor(schema_descriptor),
         detector=frictionless.Detector(schema_sync=True),
-        dialect=frictionless.Dialect(header_case=False)
+        dialect=frictionless.Dialect(header_case=False),
     )
     report = frictionless.validate(resource)
     assert report.valid

--- a/tests/table/test_header.py
+++ b/tests/table/test_header.py
@@ -75,18 +75,18 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
         for error, type_expected in zip(errors, tc["types_errors_expected"]):
             assert error.type == type_expected
 
-    # # Ignore header_case
-    # schema_descriptor = {
-    #     "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-    #     "fields": [{"name": "A", "constraints": {"required": True}}],
-    #     "primaryKey": ["A"],
-    # }
+    # Ignore header_case
+    schema_descriptor = {
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [{"name": "A", "constraints": {"required": True}}],
+        "primaryKey": ["A"],
+    }
 
-    # resource = TableResource(
-    #     source=[["a"], ["foo"]],
-    #     schema=Schema.from_descriptor(schema_descriptor),
-    #     detector=frictionless.Detector(schema_sync=True),
-    #     dialect=frictionless.Dialect(header_case=False),
-    # )
-    # report = frictionless.validate(resource)
-    # assert report.valid
+    resource = TableResource(
+        source=[["a"], ["foo"]],
+        schema=Schema.from_descriptor(schema_descriptor),
+        detector=frictionless.Detector(schema_sync=True),
+        dialect=frictionless.Dialect(header_case=False),
+    )
+    report = frictionless.validate(resource)
+    assert report.valid


### PR DESCRIPTION
- fixes #1633 
---
This PR fix unexpected KeyError raised when a primary key used in shema is missing in the tabular data to validate.
For example:
```
data = [["B"], ["b"]]
schema = {
        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
        "fields": [
            {"name": "A"},
            {"name": "B"}
        ],
        "primaryKey": ["A"]
    }
```
This PR adds some test cases: 
- two test cases to ensure that when a label related to the schema primary key is missing, the validation report is invalid with single missing-label error:
   - a test case with the schema containing the primary key field not specified as 'required' 
   - a test case with the schema containing the primary key field specified as 'required'
- a test case to deal with insensitivity case in the data label corresponding to the primary key schema field: the validation report is valid

NB: to deal with  insensitivity case, this PR should be rebased the branch related to this [PR](https://github.com/frictionlessdata/frictionless-py/pull/1638) 

Through this PR, I also suggest a refactoring to introduce intermediary `TableResource` methods to create `cells` related to primary key schema.
