### PR TITLE
Fix 1633 unexpected key error with primary key in schema and 1635 unexpected missing label error when ignoring header case

### DIFF
--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -408,7 +408,7 @@ class Detector:
             if labels:
                 case_sensitive = options["header_case"]
 
-                if case_sensitive:
+                if not case_sensitive:
                     labels = [label.lower() for label in labels]
 
                 if len(labels) != len(set(labels)):

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -505,21 +505,6 @@ class Detector:
                 label.lower() for label in labels
             ]
 
-    # def add_missing_primary_key_to_schema_fields(
-    #     self,
-    #     field: Field,
-    #     schema: Schema,
-    #     labels: List[str],
-    #     case_sensitive: bool,
-    # ):
-    #     if self.primary_key_field_not_in_labels(
-    #         field,
-    #         schema,
-    #         labels,
-    #         case_sensitive,
-    #     ):
-    #         schema.add_field(field)
-
     @staticmethod
     def primary_key_field_name_not_in_labels(
         field: Field,

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -487,10 +487,10 @@ class Detector:
         """
         for _, field in fields_mapping.items():
             # For required fields or primary key that are missing #
-            if self.field_name_not_in_labels(
+            if self.field_is_required(
+                field, schema, case_sensitive
+            ) and self.field_name_not_in_labels(
                 field, labels, case_sensitive
-            ) or self.primary_key_field_name_not_in_labels(
-                field, schema, labels, case_sensitive
             ):
                 schema.add_field(field)
 
@@ -499,30 +499,23 @@ class Detector:
         field: Field, labels: List[str], case_sensitive: bool
     ) -> bool:
         if case_sensitive:
-            return field.required and field.name not in labels
+            return field.name not in labels
         else:
-            return field.required and field.name.lower() not in [
+            return field.name.lower() not in [
                 label.lower() for label in labels
             ]
 
     @staticmethod
-    def primary_key_field_name_not_in_labels(
+    def field_is_required(
         field: Field,
         schema: Schema,
-        labels: List[str],
         case_sensitive: bool,
     ) -> bool:
         if case_sensitive:
-            return (
-                not field.required
-                and field.name in schema.primary_key
-                and field.name not in labels
-            )
+            return field.required or field.name in schema.primary_key
         else:
             lower_primary_key = [pk.lower() for pk in schema.primary_key]
-            lower_labels = [label.lower() for label in labels]
             return (
-                not field.required
-                and field.name.lower() in lower_primary_key
-                and field.name.lower() not in lower_labels
+                field.required
+                or field.name.lower() in lower_primary_key
             )

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -420,7 +420,7 @@ class Detector:
                     schema.fields, case_sensitive  # type: ignore
                 )
 
-                self.add_fields_to_schema_among_labels(
+                self.rearrange_schema_fields_given_labels(
                     mapped_fields, schema, labels, case_sensitive  # type: ignore
                 )
 
@@ -459,7 +459,7 @@ class Detector:
             return {field.name.lower(): field for field in fields}
 
     @staticmethod
-    def add_fields_to_schema_among_labels(
+    def rearrange_schema_fields_given_labels(
         fields_mapped: Dict[str, Field],
         schema: Schema,
         labels: List[str],

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -483,6 +483,7 @@ class Detector:
         case_sensitive: bool,
     ):
         for _, field in fields_map.items():
+            #TODO use self.field_name_not_in_labels
             if case_sensitive:
                 if field and field.required and field.name not in labels:
                     schema.add_field(field)
@@ -493,3 +494,20 @@ class Detector:
                     and field.name.lower() not in [label.lower() for label in labels]
                 ):
                     schema.add_field(field)
+
+    @staticmethod
+    def field_name_not_in_labels(
+        field: Field,
+        labels: List[str],
+        case_sensitive: bool
+    ) -> bool:
+        if case_sensitive:
+            return field and field.required and field.name not in labels
+        else:
+            return (
+                    field
+                    and field.required
+                    and field.name.lower() not in [
+                        label.lower() for label in labels
+                        ]
+            )

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -413,7 +413,8 @@ class Detector:
                 case_sensitive = options["header_case"]
 
                 mapped_fields = self.mapped_schema_fields_names(
-                    schema.fields, case_sensitive  # type: ignore
+                    schema.fields,  # type: ignore
+                    case_sensitive,
                 )
 
                 self.rearrange_schema_fields_given_labels(
@@ -442,13 +443,7 @@ class Detector:
     def mapped_schema_fields_names(
         fields: List[Field], case_sensitive: bool
     ) -> Dict[str, Field]:
-        """Create a dictionnary to map fields name with schema fields
-        considering case sensitivity
-
-        Args:
-            fields: list of original schema fields
-            case_sensitive: True if case sensitive, False else
-        """
+        """Create a dictionnary to map field names with schema fields"""
         if case_sensitive:
             return {field.name: field for field in fields}
         else:
@@ -461,7 +456,10 @@ class Detector:
         labels: List[str],
         case_sensitive: bool,
     ):
+        """Rearrange fields according to the order of labels. All fields
+        missing from labels are dropped"""
         schema.clear_fields()
+
         for name in labels:
             default_field = Field.from_descriptor({"name": name, "type": "any"})
             if case_sensitive:

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -505,26 +505,39 @@ class Detector:
                 label.lower() for label in labels
             ]
 
-    @staticmethod
     def add_missing_primary_key_to_schema_fields(
+        self,
         field: Field,
         schema: Schema,
         labels: List[str],
         case_sensitive: bool,
     ):
+        if self.primary_key_field_not_in_labels(
+            field,
+            schema,
+            labels,
+            case_sensitive,
+        ):
+            schema.add_field(field)
+
+    @staticmethod
+    def primary_key_field_not_in_labels(
+        field: Field,
+        schema: Schema,
+        labels: List[str],
+        case_sensitive: bool,
+    ) -> bool:
         if case_sensitive:
-            if (
+            return (
                 not field.required
                 and field.name in schema.primary_key
                 and field.name not in labels
-            ):
-                schema.add_field(field)
+            )
         else:
             lower_primary_key = [pk.lower() for pk in schema.primary_key]
             lower_labels = [label.lower() for label in labels]
-            if (
+            return (
                 not field.required
                 and field.name.lower() in lower_primary_key
                 and field.name.lower() not in lower_labels
-            ):
-                schema.add_field(field)
+            )

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -460,7 +460,7 @@ class Detector:
 
     @staticmethod
     def rearrange_schema_fields_given_labels(
-        fields_mapped: Dict[str, Field],
+        fields_mapping: Dict[str, Field],
         schema: Schema,
         labels: List[str],
         case_sensitive: bool,
@@ -469,14 +469,14 @@ class Detector:
         for name in labels:
             default_field = Field.from_descriptor({"name": name, "type": "any"})
             if case_sensitive:
-                field = fields_mapped.get(name, default_field)
+                field = fields_mapping.get(name, default_field)
             else:
-                field = fields_mapped.get(name.lower(), default_field)
+                field = fields_mapping.get(name.lower(), default_field)
             schema.add_field(field)
 
     def add_missing_required_labels_to_schema_fields(
         self,
-        fields_map: Dict[str, Field],
+        fields_mapping: Dict[str, Field],
         schema: Schema,
         labels: List[str],
         case_sensitive: bool,
@@ -484,7 +484,7 @@ class Detector:
         """This method aims to add missing required labels and
         primary key field not in labels to schema fields
         """
-        for _, field in fields_map.items():
+        for _, field in fields_mapping.items():
             # For required fields or primary key that are missing #
             if self.field_name_not_in_labels(
                 field, labels, case_sensitive

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import codecs
 import os
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import attrs
 

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -412,10 +412,6 @@ class Detector:
 
                 case_sensitive = options["header_case"]
 
-                assert schema
-                assert schema.fields
-                assert all(isinstance(field, Field) for field in schema.fields)
-
                 mapped_fields = self.mapped_schema_fields_names(
                     schema.fields, case_sensitive  # type: ignore
                 )
@@ -440,7 +436,7 @@ class Detector:
                 field_descriptor.update(field_patch)
             schema = Schema.from_descriptor(descriptor)
 
-        return schema  # type: ignore
+        return schema
 
     @staticmethod
     def mapped_schema_fields_names(

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -298,7 +298,7 @@ class Detector:
         labels: Optional[List[str]] = None,
         schema: Optional[Schema] = None,
         field_candidates: List[Dict[str, Any]] = settings.DEFAULT_FIELD_CANDIDATES,
-        **options: Any
+        **options: Any,
     ) -> Schema:
         """Detect schema from fragment
 
@@ -412,7 +412,7 @@ class Detector:
                 if options["header_case"]:
                     mapping = {field.name: field for field in schema.fields}  # type: ignore
                 else:
-                    mapping = {field.name.lower(): field for field in schema.fields} # type: ignore
+                    mapping = {field.name.lower(): field for field in schema.fields}  # type: ignore
                 schema.clear_fields()
                 for name in labels:
                     if options["header_case"]:
@@ -428,8 +428,12 @@ class Detector:
                         if field and field.required and field.name not in labels:
                             schema.add_field(field)
                     else:
-                        if field and field.required and field.name.lower() not in [
-                            label.lower() for label in labels]:
+                        if (
+                            field
+                            and field.required
+                            and field.name.lower()
+                            not in [label.lower() for label in labels]
+                        ):
                             schema.add_field(field)
 
         # Patch schema

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -485,12 +485,15 @@ class Detector:
         labels: List[str],
         case_sensitive: bool,
     ):
+        """This method aims to add missing required labels and
+        primary key field not in labels to schema fields
+        """
         for _, field in fields_map.items():
-            # For required fields that are missing
+            # For required fields or primary key that are missing #
             if self.field_name_not_in_labels(
                 field, labels, case_sensitive
             ) or self.primary_key_field_name_not_in_labels(
-                field, schema, labels, case_sensitive  # type: ignore
+                field, schema, labels, case_sensitive
             ):
                 schema.add_field(field)
 

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -421,11 +421,11 @@ class Detector:
                 )
 
                 self.rearrange_schema_fields_given_labels(
-                    mapped_fields, schema, labels, case_sensitive  # type: ignore
+                    mapped_fields, schema, labels, case_sensitive
                 )
 
                 self.add_missing_required_labels_to_schema_fields(
-                    mapped_fields, schema, labels, case_sensitive  # type: ignore
+                    mapped_fields, schema, labels, case_sensitive
                 )
 
         # Patch schema
@@ -445,7 +445,7 @@ class Detector:
     @staticmethod
     def mapped_schema_fields_names(
         fields: List[Field], case_sensitive: bool
-    ) -> Dict[str, Optional[Field]]:
+    ) -> Dict[str, Field]:
         """Create a dictionnary to map fields name with schema fields
         considering case sensitivity
 

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -487,12 +487,12 @@ class Detector:
     ):
         for _, field in fields_map.items():
             # For required fields that are missing
-            if self.field_name_not_in_labels(field, labels, case_sensitive):
-                schema.add_field(field)
-            # For primary field that are missing
-            self.add_missing_primary_key_to_schema_fields(
+            if self.field_name_not_in_labels(
+                field, labels, case_sensitive
+            ) or self.primary_key_field_name_not_in_labels(
                 field, schema, labels, case_sensitive  # type: ignore
-            )
+            ):
+                schema.add_field(field)
 
     @staticmethod
     def field_name_not_in_labels(
@@ -505,23 +505,23 @@ class Detector:
                 label.lower() for label in labels
             ]
 
-    def add_missing_primary_key_to_schema_fields(
-        self,
-        field: Field,
-        schema: Schema,
-        labels: List[str],
-        case_sensitive: bool,
-    ):
-        if self.primary_key_field_not_in_labels(
-            field,
-            schema,
-            labels,
-            case_sensitive,
-        ):
-            schema.add_field(field)
+    # def add_missing_primary_key_to_schema_fields(
+    #     self,
+    #     field: Field,
+    #     schema: Schema,
+    #     labels: List[str],
+    #     case_sensitive: bool,
+    # ):
+    #     if self.primary_key_field_not_in_labels(
+    #         field,
+    #         schema,
+    #         labels,
+    #         case_sensitive,
+    #     ):
+    #         schema.add_field(field)
 
     @staticmethod
-    def primary_key_field_not_in_labels(
+    def primary_key_field_name_not_in_labels(
         field: Field,
         schema: Schema,
         labels: List[str],

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -495,10 +495,9 @@ class Detector:
         field: Field, labels: List[str], case_sensitive: bool
     ) -> bool:
         if case_sensitive:
-            return field and field.required and field.name not in labels
+            return field.required and field.name not in labels
         else:
             return (
-                field
-                and field.required
+                field.required
                 and field.name.lower() not in [label.lower() for label in labels]
             )

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -489,9 +489,7 @@ class Detector:
             # For required fields or primary key that are missing #
             if self.field_is_required(
                 field, schema, case_sensitive
-            ) and self.field_name_not_in_labels(
-                field, labels, case_sensitive
-            ):
+            ) and self.field_name_not_in_labels(field, labels, case_sensitive):
                 schema.add_field(field)
 
     @staticmethod
@@ -501,9 +499,7 @@ class Detector:
         if case_sensitive:
             return field.name not in labels
         else:
-            return field.name.lower() not in [
-                label.lower() for label in labels
-            ]
+            return field.name.lower() not in [label.lower() for label in labels]
 
     @staticmethod
     def field_is_required(
@@ -515,7 +511,4 @@ class Detector:
             return field.required or field.name in schema.primary_key
         else:
             lower_primary_key = [pk.lower() for pk in schema.primary_key]
-            return (
-                field.required
-                or field.name.lower() in lower_primary_key
-            )
+            return field.required or field.name.lower() in lower_primary_key

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import codecs
 import os
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import attrs
 
@@ -450,12 +450,8 @@ class Detector:
         considering case sensitivity
 
         Args:
-            fields (Union[List[None], List[Field]]): list of original
-                                                        schema fields
-            case_sensitive (bool): True if case sensitive, False else
-
-        Returns:
-            Dict[str, Optional[Field]]
+            fields: list of original schema fields
+            case_sensitive: True if case sensitive, False else
         """
         if case_sensitive:
             return {field.name: field for field in fields}

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -424,7 +424,6 @@ class Detector:
                     mapped_fields, schema, labels, case_sensitive  # type: ignore
                 )
 
-                # For required fields that are missing
                 self.add_missing_required_labels_to_schema_fields(
                     mapped_fields, schema, labels, case_sensitive  # type: ignore
                 )
@@ -487,7 +486,11 @@ class Detector:
         case_sensitive: bool,
     ):
         for _, field in fields_map.items():
+            # For required fields that are missing
             if self.field_name_not_in_labels(field, labels, case_sensitive):
+                schema.add_field(field)
+            # For primary field that are missing
+            if field and not field.required and field.name in schema.primary_key and field.name not in labels:
                 schema.add_field(field)
 
     @staticmethod

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -469,9 +469,10 @@ class Detector:
         for name in labels:
             default_field = Field.from_descriptor({"name": name, "type": "any"})
             if case_sensitive:
-                field = fields_mapping.get(name, default_field)
+                index_name = name
             else:
-                field = fields_mapping.get(name.lower(), default_field)
+                index_name = name.lower()
+            field = fields_mapping.get(index_name, default_field)
             schema.add_field(field)
 
     def add_missing_required_labels_to_schema_fields(

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -453,7 +453,7 @@ class Detector:
         Args:
             fields (Union[List[None], List[Field]]): list of original
                                                         schema fields
-            case_sensitive (bool)
+            case_sensitive (bool): True if case sensitive, False else
 
         Returns:
             Dict[str, Optional[Field]]

--- a/frictionless/resource/__spec__/test_security.py
+++ b/frictionless/resource/__spec__/test_security.py
@@ -27,9 +27,11 @@ def test_resource_source_path_error_bad_path_not_safe_traversing():
         Resource(
             {
                 "name": "name",
-                "path": "data/../data/table.csv"
-                if not platform.type == "windows"
-                else "data\\..\\table.csv",
+                "path": (
+                    "data/../data/table.csv"
+                    if not platform.type == "windows"
+                    else "data\\..\\table.csv"
+                ),
             }
         )
     error = excinfo.value.error

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -389,13 +389,21 @@ class TableResource(Resource):
 
         # NB: missing required labels are not included in the
         # field_info parameter used for row creation
-        if self.detector.schema_sync and self.dialect.header_case:
+        if self.detector.schema_sync:
             for field in self.schema.fields:
-                if field.name not in self.labels and field.name in field_info["names"]:
-                    field_index = field_info["names"].index(field.name)
-                    del field_info["names"][field_index]
-                    del field_info["objects"][field_index]
-                    del field_info["mapping"][field.name]
+                if self.dialect.header_case:
+                    if field.name not in self.labels and field.name in field_info["names"]:
+                        field_index = field_info["names"].index(field.name)
+                        del field_info["names"][field_index]
+                        del field_info["objects"][field_index]
+                        del field_info["mapping"][field.name]
+                else:  # Ignore case
+                    if field.name.lower() not in [label.lower() for label in self.labels] \
+                            and field.name.lower() in [field_info_name.lower() for field_info_name in field_info["names"]]:
+                        field_index = field_info["names"].index(field.name)
+                        del field_info["names"][field_index]
+                        del field_info["objects"][field_index]
+                        del field_info["mapping"][field.name]
 
         # Create row stream
         self.__row_stream = row_stream()

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -335,8 +335,7 @@ class TableResource(Resource):
                 # Primary Key Error
                 if is_integrity and self.schema.primary_key:
                     try:
-                        cells = self.primary_key_cells(row,
-                                                       self.dialect.header_case)
+                        cells = self.primary_key_cells(row, self.dialect.header_case)
                     except KeyError:
                         # Row does not have primary_key as key
                         # There should already be a missing-label error in
@@ -443,17 +442,13 @@ class TableResource(Resource):
         del field_info["objects"][field_index]
         del field_info["mapping"][field_name]
 
-    # Read
-    def primary_key_cells(
-        self,
-        row: Row,
-        case_sensitive: bool
-    ) -> Tuple[str, Any]:
-        """Create a tuple containg all cells related to primary_key
-        """
-        return tuple(row[label] for label in
-                     self.labels_related_to_primary_key(row, case_sensitive))
-    
+    def primary_key_cells(self, row: Row, case_sensitive: bool) -> Tuple[str, Any]:
+        """Create a tuple containg all cells related to primary_key"""
+        return tuple(
+            row[label]
+            for label in self.labels_related_to_primary_key(row, case_sensitive)
+        )
+
     def labels_related_to_primary_key(
         self,
         row: Row,
@@ -465,11 +460,10 @@ class TableResource(Resource):
         if case_sensitive:
             labels_primary_key = self.schema.primary_key
         else:
-            lower_primary_key = [
-                pk.lower() for pk in self.schema.primary_key
+            lower_primary_key = [pk.lower() for pk in self.schema.primary_key]
+            labels_primary_key = [
+                label for label in row.field_names if label.lower() in lower_primary_key
             ]
-            labels_primary_key = [label for label in row.field_names
-                                  if label.lower() in lower_primary_key]
         return labels_primary_key
 
     # Read

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -454,14 +454,11 @@ class TableResource(Resource):
         if case_sensitive:
             cells = tuple(row[name] for name in self.schema.primary_key)
         else:  # Ignore case
-            cells = ()
             lower_primary_keys = [
                 pk.lower() for pk in self.schema.primary_key
             ]
-            # cells = tuple(row[label] if (label.lower() for label in row.field_names) in lower_primary_keys )
-            for label in row.field_names:
-                if label.lower() in lower_primary_keys:
-                    cells = cells + (row[label],)
+            labels_primary_key = [label for label in row.field_names if label.lower() in lower_primary_keys]
+            cells = tuple(row[label] for label in labels_primary_key)
         return cells
 
     # Read

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -350,12 +350,11 @@ class TableResource(Resource):
                             match = memory_primary.get(cells)
                             memory_primary[cells] = row.row_number
                             if match:
-                                if match:
-                                    note = "the same as in the row at position %s" % match
-                                    error = errors.PrimaryKeyError.from_row(
-                                        row, note=note
-                                    )
-                                    row.errors.append(error)
+                                note = "the same as in the row at position %s" % match
+                                error = errors.PrimaryKeyError.from_row(
+                                    row, note=note
+                                )
+                                row.errors.append(error)
 
                 # Foreign Key Error
                 if is_integrity and foreign_groups:

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -204,6 +204,7 @@ class TableResource(Resource):
             labels=self.labels,
             schema=self.schema,
             field_candidates=system.detect_field_candidates(),
+            header_case=self.dialect.header_case
         )
         self.stats.fields = len(self.schema.fields)
 
@@ -388,14 +389,15 @@ class TableResource(Resource):
 
         # NB: missing required labels are not included in the
         # field_info parameter used for row creation
-        if self.detector.schema_sync:
+        if self.detector.schema_sync and self.dialect.header_case:
             for field in self.schema.fields:
                 if field.name not in self.labels and field.name in field_info["names"]:
                     field_index = field_info["names"].index(field.name)
                     del field_info["names"][field_index]
                     del field_info["objects"][field_index]
                     del field_info["mapping"][field.name]
-        # # Create row stream
+
+        # Create row stream
         self.__row_stream = row_stream()
 
     # Read

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -392,14 +392,20 @@ class TableResource(Resource):
         if self.detector.schema_sync:
             for field in self.schema.fields:
                 if self.dialect.header_case:
-                    if field.name not in self.labels and field.name in field_info["names"]:
+                    if (
+                        field.name not in self.labels
+                        and field.name in field_info["names"]
+                    ):
                         field_index = field_info["names"].index(field.name)
                         del field_info["names"][field_index]
                         del field_info["objects"][field_index]
                         del field_info["mapping"][field.name]
                 else:  # Ignore case
-                    if field.name.lower() not in [label.lower() for label in self.labels] \
-                            and field.name.lower() in [field_info_name.lower() for field_info_name in field_info["names"]]:
+                    if field.name.lower() not in [
+                        label.lower() for label in self.labels
+                    ] and field.name.lower() in [
+                        field_info_name.lower() for field_info_name in field_info["names"]
+                    ]:
                         field_index = field_info["names"].index(field.name)
                         del field_info["names"][field_index]
                         del field_info["objects"][field_index]

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -440,20 +440,16 @@ class TableResource(Resource):
         del field_info["mapping"][field_name]
 
     def primary_key_cells(self, row: Row, case_sensitive: bool) -> Tuple[Any, ...]:
-        """Create a tuple containg all cells related to primary_key"""
-        return tuple(
-            row[label]
-            for label in self.labels_related_to_primary_key(row, case_sensitive)
-        )
+        """Create a tuple containg all cells from a given row associated to primary
+        keys"""
+        return tuple(row[label] for label in self.primary_key_labels(row, case_sensitive))
 
-    def labels_related_to_primary_key(
+    def primary_key_labels(
         self,
         row: Row,
         case_sensitive: bool,
     ) -> List[str]:
-        """Create a list of TableResource labels which correspond to the
-        primary_key schema considering case-sensitivity
-        """
+        """Create a list of TableResource labels that are primary keys"""
         if case_sensitive:
             labels_primary_key = self.schema.primary_key
         else:

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -408,13 +408,13 @@ class TableResource(Resource):
         self, field: Field, field_info: Dict[str, Any]
     ):
         is_case_sensitive = self.dialect.header_case
-        if self.field_is_missing(
+        if self.label_is_missing(
             field.name, field_info["names"], self.labels, is_case_sensitive
         ):
             self.remove_field_from_field_info(field.name, field_info)
 
     @staticmethod
-    def field_is_missing(
+    def label_is_missing(
         field_name: str,
         expected_field_names: List[str],
         table_labels: types.ILabels,
@@ -439,7 +439,7 @@ class TableResource(Resource):
         del field_info["objects"][field_index]
         del field_info["mapping"][field_name]
 
-    def primary_key_cells(self, row: Row, case_sensitive: bool) -> Tuple[Any]:
+    def primary_key_cells(self, row: Row, case_sensitive: bool) -> Tuple[Any, ...]:
         """Create a tuple containg all cells related to primary_key"""
         return tuple(
             row[label]
@@ -451,7 +451,7 @@ class TableResource(Resource):
         row: Row,
         case_sensitive: bool,
     ) -> List[str]:
-        """Create a list of TabelResource labels which correspond to the
+        """Create a list of TableResource labels which correspond to the
         primary_key schema considering case-sensitivity
         """
         if case_sensitive:

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -334,19 +334,24 @@ class TableResource(Resource):
 
                 # Primary Key Error
                 if is_integrity and self.schema.primary_key:
-                    cells = tuple(row[name] for name in self.schema.primary_key)
-                    if set(cells) == {None}:
-                        note = 'cells composing the primary keys are all "None"'
-                        error = errors.PrimaryKeyError.from_row(row, note=note)
-                        row.errors.append(error)
+                    try:
+                        cells = tuple(row[name] for name in self.schema.primary_key)
+                    except KeyError:
+                        # Row does not have primary_key as key
+                        pass
                     else:
-                        match = memory_primary.get(cells)
-                        memory_primary[cells] = row.row_number
-                        if match:
+                        if set(cells) == {None}:
+                            note = 'cells composing the primary keys are all "None"'
+                            error = errors.PrimaryKeyError.from_row(row, note=note)
+                            row.errors.append(error)
+                        else:
+                            match = memory_primary.get(cells)
+                            memory_primary[cells] = row.row_number
                             if match:
-                                note = "the same as in the row at position %s" % match
-                                error = errors.PrimaryKeyError.from_row(row, note=note)
-                                row.errors.append(error)
+                                if match:
+                                    note = "the same as in the row at position %s" % match
+                                    error = errors.PrimaryKeyError.from_row(row, note=note)
+                                    row.errors.append(error)
 
                 # Foreign Key Error
                 if is_integrity and foreign_groups:

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -398,8 +398,8 @@ class TableResource(Resource):
                 yield row
 
         if self.detector.schema_sync:
-            # Missing required labels have in 'field_info'
-            # parameter used for row creation
+            # Missing required labels are not included in the
+            # field_info parameter used for row creation
             for field in self.schema.fields:
                 self.remove_missing_required_label_from_field_info(field, field_info)
 

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -418,7 +418,7 @@ class TableResource(Resource):
     @staticmethod
     def field_is_missing(
         field_name: str,
-        expected_fields_names: List[str],
+        expected_field_names: List[str],
         table_labels: types.ILabels,
         case_sensitive: bool,
     ) -> bool:
@@ -428,11 +428,11 @@ class TableResource(Resource):
         if not case_sensitive:
             field_name = field_name.lower()
             table_labels = [label.lower() for label in table_labels]
-            expected_fields_names = [
-                field_name.lower() for field_name in expected_fields_names
+            expected_field_names = [
+                field_name.lower() for field_name in expected_field_names
             ]
 
-        return field_name not in table_labels and field_name in expected_fields_names
+        return field_name not in table_labels and field_name in expected_field_names
 
     @staticmethod
     def remove_field_from_field_info(field_name: str, field_info: Dict[str, Any]):

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -399,7 +399,7 @@ class TableResource(Resource):
                 yield row
 
         if self.detector.schema_sync:
-            # Missing required labels have  in 'field_info'
+            # Missing required labels have in 'field_info'
             # parameter used for row creation
             for field in self.schema.fields:
                 self.remove_missing_required_label_from_field_info(field, field_info)

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -448,18 +448,29 @@ class TableResource(Resource):
         self,
         row: Row,
         case_sensitive: bool
-    ) -> Tuple[Row, Any]:
+    ) -> Tuple[str, Any]:
         """Create a tuple containg all cells related to primary_key
         """
+        return tuple(row[label] for label in
+                     self.labels_related_to_primary_key(row, case_sensitive))
+    
+    def labels_related_to_primary_key(
+        self,
+        row: Row,
+        case_sensitive: bool,
+    ) -> List[str]:
+        """Create a list of TabelResource labels which correspond to the
+        primary_key schema considering case-sensitivity
+        """
         if case_sensitive:
-            cells = tuple(row[name] for name in self.schema.primary_key)
-        else:  # Ignore case
-            lower_primary_keys = [
+            labels_primary_key = self.schema.primary_key
+        else:
+            lower_primary_key = [
                 pk.lower() for pk in self.schema.primary_key
             ]
-            labels_primary_key = [label for label in row.field_names if label.lower() in lower_primary_keys]
-            cells = tuple(row[label] for label in labels_primary_key)
-        return cells
+            labels_primary_key = [label for label in row.field_names
+                                  if label.lower() in lower_primary_key]
+        return labels_primary_key
 
     # Read
     def read_cells(self, *, size: Optional[int] = None) -> List[List[Any]]:

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -204,7 +204,7 @@ class TableResource(Resource):
             labels=self.labels,
             schema=self.schema,
             field_candidates=system.detect_field_candidates(),
-            header_case=self.dialect.header_case
+            header_case=self.dialect.header_case,
         )
         self.stats.fields = len(self.schema.fields)
 

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -335,7 +335,11 @@ class TableResource(Resource):
                 # Primary Key Error
                 if is_integrity and self.schema.primary_key:
                     try:
-                        cells = tuple(row[name] for name in self.schema.primary_key)
+                        if self.dialect.header_case:
+                            cells = tuple(row[name] for name in self.schema.primary_key)
+                        else: # ignore case
+                            primary_key_lowers = [pk.lower() for pk in self.schema.primary_key]
+                            cells = tuple(row[name] for name in primary_key_lowers)
                     except KeyError:
                         # Row does not have primary_key as key
                         # There is a missing label corresponding to the schema

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -335,17 +335,8 @@ class TableResource(Resource):
                 # Primary Key Error
                 if is_integrity and self.schema.primary_key:
                     try:
-                        if self.dialect.header_case:
-                            cells = tuple(row[name] for name in self.schema.primary_key)
-                        else:  # Ignore case
-                            cells = ()
-                            lower_primary_keys = [
-                                pk.lower() for pk in self.schema.primary_key
-                            ]
-                            # cells = tuple(row[label] if (label.lower() for label in row.field_names) in lower_primary_keys )
-                            for label in row.field_names:
-                                if label.lower() in lower_primary_keys:
-                                    cells = cells + (row[label],)
+                        cells = self.primary_key_cells(row,
+                                                       self.dialect.header_case)
                     except KeyError:
                         # Row does not have primary_key as key
                         # There should already be a missing-label error in
@@ -453,7 +444,27 @@ class TableResource(Resource):
         del field_info["mapping"][field_name]
 
     # Read
+    def primary_key_cells(
+        self,
+        row: Row,
+        case_sensitive: bool
+    ) -> Tuple[Row, Any]:
+        """Create a tuple containg all cells related to primary_key
+        """
+        if case_sensitive:
+            cells = tuple(row[name] for name in self.schema.primary_key)
+        else:  # Ignore case
+            cells = ()
+            lower_primary_keys = [
+                pk.lower() for pk in self.schema.primary_key
+            ]
+            # cells = tuple(row[label] if (label.lower() for label in row.field_names) in lower_primary_keys )
+            for label in row.field_names:
+                if label.lower() in lower_primary_keys:
+                    cells = cells + (row[label],)
+        return cells
 
+    # Read
     def read_cells(self, *, size: Optional[int] = None) -> List[List[Any]]:
         """Read lists into memory
 

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -347,8 +347,8 @@ class TableResource(Resource):
                             error = errors.PrimaryKeyError.from_row(row, note=note)
                             row.errors.append(error)
                         else:
-                            match = memory_primary.get(cells)  # type: ignore
-                            memory_primary[cells] = row.row_number  # type: ignore
+                            match = memory_primary.get(cells)
+                            memory_primary[cells] = row.row_number
                             if match:
                                 if match:
                                     note = "the same as in the row at position %s" % match
@@ -442,7 +442,7 @@ class TableResource(Resource):
         del field_info["objects"][field_index]
         del field_info["mapping"][field_name]
 
-    def primary_key_cells(self, row: Row, case_sensitive: bool) -> Tuple[str, Any]:
+    def primary_key_cells(self, row: Row, case_sensitive: bool) -> Tuple[Any]:
         """Create a tuple containg all cells related to primary_key"""
         return tuple(
             row[label]

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -351,9 +351,7 @@ class TableResource(Resource):
                             memory_primary[cells] = row.row_number
                             if match:
                                 note = "the same as in the row at position %s" % match
-                                error = errors.PrimaryKeyError.from_row(
-                                    row, note=note
-                                )
+                                error = errors.PrimaryKeyError.from_row(row, note=note)
                                 row.errors.append(error)
 
                 # Foreign Key Error

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -337,9 +337,13 @@ class TableResource(Resource):
                     try:
                         if self.dialect.header_case:
                             cells = tuple(row[name] for name in self.schema.primary_key)
-                        else: # ignore case
-                            primary_key_lowers = [pk.lower() for pk in self.schema.primary_key]
-                            cells = tuple(row[name] for name in primary_key_lowers)
+                        else:  # ignore case
+                            cells = ()
+                            lower_primary_keys = [pk.lower() for pk in self.schema.primary_key]
+                            # cells = tuple(row[label] if (label.lower() for label in row.field_names) in lower_primary_keys )
+                            for label in row.field_names:
+                                if label.lower() in lower_primary_keys:
+                                    cells = cells + (row[label],)
                     except KeyError:
                         # Row does not have primary_key as key
                         # There is a missing label corresponding to the schema

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -337,29 +337,28 @@ class TableResource(Resource):
                     try:
                         if self.dialect.header_case:
                             cells = tuple(row[name] for name in self.schema.primary_key)
-                        else:  # ignore case
+                        else:  # Ignore case
                             cells = ()
-                            lower_primary_keys = [pk.lower() for pk in self.schema.primary_key]
+                            lower_primary_keys = [
+                                pk.lower() for pk in self.schema.primary_key
+                            ]
                             # cells = tuple(row[label] if (label.lower() for label in row.field_names) in lower_primary_keys )
                             for label in row.field_names:
                                 if label.lower() in lower_primary_keys:
                                     cells = cells + (row[label],)
                     except KeyError:
                         # Row does not have primary_key as key
-                        # There is a missing label corresponding to the schema
-                        note = (
-                            f"Inexistant label for primary key {self.schema.primary_key}"
-                        )
-                        error = errors.PrimaryKeyError.from_row(row, note=note)
-                        row.errors.append(error)
+                        # There should already be a missing-label error in
+                        # in self.header corresponding to the schema primary key
+                        assert not self.header.valid
                     else:
                         if set(cells) == {None}:
                             note = 'cells composing the primary keys are all "None"'
                             error = errors.PrimaryKeyError.from_row(row, note=note)
                             row.errors.append(error)
                         else:
-                            match = memory_primary.get(cells)
-                            memory_primary[cells] = row.row_number
+                            match = memory_primary.get(cells)  # type: ignore
+                            memory_primary[cells] = row.row_number  # type: ignore
                             if match:
                                 if match:
                                     note = "the same as in the row at position %s" % match

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -337,7 +337,7 @@ class TableResource(Resource):
                     try:
                         cells = self.primary_key_cells(row, self.dialect.header_case)
                     except KeyError:
-                        # Row does not have primary_key as key
+                        # Row does not have primary_key as label
                         # There should already be a missing-label error in
                         # in self.header corresponding to the schema primary key
                         assert not self.header.valid

--- a/frictionless/resources/table.py
+++ b/frictionless/resources/table.py
@@ -338,7 +338,12 @@ class TableResource(Resource):
                         cells = tuple(row[name] for name in self.schema.primary_key)
                     except KeyError:
                         # Row does not have primary_key as key
-                        pass
+                        # There is a missing label corresponding to the schema
+                        note = (
+                            f"Inexistant label for primary key {self.schema.primary_key}"
+                        )
+                        error = errors.PrimaryKeyError.from_row(row, note=note)
+                        row.errors.append(error)
                     else:
                         if set(cells) == {None}:
                             note = 'cells composing the primary keys are all "None"'
@@ -350,7 +355,9 @@ class TableResource(Resource):
                             if match:
                                 if match:
                                     note = "the same as in the row at position %s" % match
-                                    error = errors.PrimaryKeyError.from_row(row, note=note)
+                                    error = errors.PrimaryKeyError.from_row(
+                                        row, note=note
+                                    )
                                     row.errors.append(error)
 
                 # Foreign Key Error

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -47,11 +47,11 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
             "nb_errors": 1,
             "types_errors_expected": ["missing-label"],
         },
-        # { # This test case raise the unexpected KeyError we want to fix
-        #     "constraints": {},
-        #     "nb_errors": 1,
-        #     "types_errors_expected": ["missing-label"],
-        # },
+        {
+            "constraints": {},
+            "nb_errors": 1,
+            "types_errors_expected": ["missing-label"],
+        },
     ]
 
     for tc in test_cases:
@@ -74,24 +74,6 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
         assert len(errors) == tc["nb_errors"]
         for error, type_expected in zip(errors, tc["types_errors_expected"]):
             assert error.type == type_expected
-
-    # TODO: fix this isolated test case and refactoring
-    schema_descriptor = {
-            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-            "fields": [{"name": "A"}],
-            "primaryKey": ["A"],
-        }
-
-    resource = TableResource(
-            source=[["B"], ["foo"]],
-            schema=Schema.from_descriptor(schema_descriptor),
-            detector=frictionless.Detector(schema_sync=True),
-        )
-
-    report = frictionless.validate(resource)
-    errors = report.tasks[0].errors
-    assert len(errors) == 1
-    assert errors[0].type == "missing-label"
 
     # # Ignore header_case
     # schema_descriptor = {

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -47,8 +47,13 @@ def test_missing_label():
     [
         ([["B"], ["foo"]], {"required": True}, False, 1, ["missing-label"], True),
         ([["B"], ["foo"]], {}, False, 1, ["missing-label"], True),
-        ([["a"], ["foo"]], {"required": True}, True, 0, [], False),  # Ignore header_case
-        ([["a"], ["foo"]], {}, True, 0, [], False),  # Ignore header_case
+        ([["a"], ["foo"]], {"required": True}, False, 1, ["missing-label"], True),
+        ([["a"], ["foo"]], {}, False, 1, ["missing-label"], True),
+        # Ignore header_case
+        ([["B"], ["foo"]], {"required": True}, False, 1, ["missing-label"], False),
+        ([["B"], ["foo"]], {}, False, 1, ["missing-label"], False),
+        ([["a"], ["foo"]], {"required": True}, True, 0, [], False),
+        ([["a"], ["foo"]], {}, True, 0, [], False),
     ],
 )
 def test_missing_primary_key_label_with_shema_sync_issue_1633(

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -78,6 +78,22 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
     # Ignore header_case
     schema_descriptor = {
         "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [{"name": "A"}],
+        "primaryKey": ["A"],
+    }
+
+    resource = TableResource(
+        source=[["a"], ["foo"]],
+        schema=Schema.from_descriptor(schema_descriptor),
+        detector=frictionless.Detector(schema_sync=True),
+        dialect=frictionless.Dialect(header_case=False),
+    )
+    report = frictionless.validate(resource)
+    assert report.valid
+    
+    # TODO to solve this test case needs to merge with working branch Fix-1635-...
+    schema_descriptor = {
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
         "fields": [{"name": "A", "constraints": {"required": True}}],
         "primaryKey": ["A"],
     }

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -47,11 +47,11 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
             "nb_errors": 1,
             "types_errors_expected": ["missing-label"],
         },
-        {
-            "constraints": {},
-            "nb_errors": 1,
-            "types_errors_expected": ["missing-label"],
-        },
+        # { # This test case raise the unexpected KeyError we want to fix
+        #     "constraints": {},
+        #     "nb_errors": 1,
+        #     "types_errors_expected": ["missing-label"],
+        # },
     ]
 
     for tc in test_cases:
@@ -74,6 +74,24 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
         assert len(errors) == tc["nb_errors"]
         for error, type_expected in zip(errors, tc["types_errors_expected"]):
             assert error.type == type_expected
+
+    # TODO: fix this isolated test case and refactoring
+    schema_descriptor = {
+            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+            "fields": [{"name": "A"}],
+            "primaryKey": ["A"],
+        }
+
+    resource = TableResource(
+            source=[["B"], ["foo"]],
+            schema=Schema.from_descriptor(schema_descriptor),
+            detector=frictionless.Detector(schema_sync=True),
+        )
+
+    report = frictionless.validate(resource)
+    errors = report.tasks[0].errors
+    assert len(errors) == 1
+    assert errors[0].type == "missing-label"
 
     # Ignore header_case
     schema_descriptor = {

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -57,10 +57,11 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
 
     report = frictionless.validate(resource)
 
-    assert len(report.tasks[0].errors) == 1
-    assert report.tasks[0].errors[0].type == "missing-label"
     assert not report.valid
-
+    assert len(report.tasks[0].errors) == 2
+    assert report.tasks[0].errors[0].type == "missing-label"
+    assert report.tasks[0].errors[1].type == "primary-key"
+    
     schema_descriptor = {
         "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
         "fields": [{"name": "A"}],
@@ -76,6 +77,6 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
     )
 
     report = frictionless.validate(resource)
-    print(report)
-    assert report.tasks[0].errors[0].type == "primary-key"
     assert not report.valid
+    assert len(report.tasks[0].errors) == 1
+    assert report.tasks[0].errors[0].type == "primary-key"

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -75,3 +75,19 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
         assert len(errors) == tc["nb_errors"]
         for error, type_expected in zip(errors, tc["types_errors_expected"]):
             assert error.type == type_expected
+
+    # Ignore header_case
+    schema_descriptor = {
+            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+            "fields": [{"name": "A"}],
+            "primaryKey": ["A"],
+        }
+
+    resource = TableResource(
+        source=[["a"], ["foo"]],
+        schema=Schema.from_descriptor(schema_descriptor),
+        detector=frictionless.Detector(schema_sync=True),
+        dialect=frictionless.Dialect(header_case=False)
+    )
+    report = frictionless.validate(resource)
+    assert report.valid

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -1,3 +1,5 @@
+import pytest
+
 import frictionless
 from frictionless import Schema, fields
 from frictionless.resources import TableResource
@@ -40,63 +42,37 @@ def test_missing_label():
         assert header.valid is False
 
 
-def test_missing_primary_key_label_with_shema_sync_issue_1633():
-    test_cases = [
-        {
-            "constraints": {"required": True},
-            "nb_errors": 1,
-            "types_errors_expected": ["missing-label"],
-        },
-        {
-            "constraints": {},
-            "nb_errors": 1,
-            "types_errors_expected": ["missing-label"],
-        },
-    ]
+@pytest.mark.parametrize(
+    "source, required, valid_report, nb_errors, types_errors_expected, header_case",
+    [
+        ([["B"], ["foo"]], {"required": True}, False, 1, ["missing-label"], True),
+        ([["B"], ["foo"]], {}, False, 1, ["missing-label"], True),
+        ([["a"], ["foo"]], {"required": True}, True, 0, [], False),  # Ignore header_case
+        ([["a"], ["foo"]], {}, True, 0, [], False),  # Ignore header_case
+    ],
+)
+def test_missing_primary_key_label_with_shema_sync_issue_1633(
+    source, required, valid_report, nb_errors, types_errors_expected, header_case
+):
+    schema_descriptor = {
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [{"name": "A", "constraints": required}],
+        "primaryKey": ["A"],
+    }
 
-    for tc in test_cases:
-        schema_descriptor = {
-            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-            "fields": [{"name": "A", "constraints": tc["constraints"]}],
-            "primaryKey": ["A"],
-        }
+    resource = TableResource(
+        source=source,
+        schema=Schema.from_descriptor(schema_descriptor),
+        detector=frictionless.Detector(schema_sync=True),
+        dialect=frictionless.Dialect(header_case=header_case),
+    )
 
-        resource = TableResource(
-            source=[["B"], ["foo"]],
-            schema=Schema.from_descriptor(schema_descriptor),
-            detector=frictionless.Detector(schema_sync=True),
-        )
+    report = frictionless.validate(resource)
 
-        report = frictionless.validate(resource)
+    assert report.valid == valid_report
+
+    if not report.valid:
         errors = report.tasks[0].errors
-
-        assert not report.valid
-        assert len(errors) == tc["nb_errors"]
-        for error, type_expected in zip(errors, tc["types_errors_expected"]):
+        assert len(errors) == nb_errors
+        for error, type_expected in zip(errors, types_errors_expected):
             assert error.type == type_expected
-
-    # Ignore header_case
-    test_cases = [
-        {
-            "constraints": {"required": True},
-        },
-        {
-            "constraints": {},
-        },
-    ]
-
-    for tc in test_cases:
-        schema_descriptor = {
-            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-            "fields": [{"name": "A", "constraints": tc["constraints"]}],
-            "primaryKey": ["A"],
-        }
-
-        resource = TableResource(
-            source=[["a"], ["foo"]],
-            schema=Schema.from_descriptor(schema_descriptor),
-            detector=frictionless.Detector(schema_sync=True),
-            dialect=frictionless.Dialect(header_case=False),
-        )
-        report = frictionless.validate(resource)
-        assert report.valid

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -93,18 +93,18 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
     assert len(errors) == 1
     assert errors[0].type == "missing-label"
 
-    # Ignore header_case
-    schema_descriptor = {
-        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-        "fields": [{"name": "A"}],
-        "primaryKey": ["A"],
-    }
+    # # Ignore header_case
+    # schema_descriptor = {
+    #     "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+    #     "fields": [{"name": "A", "constraints": {"required": True}}],
+    #     "primaryKey": ["A"],
+    # }
 
-    resource = TableResource(
-        source=[["a"], ["foo"]],
-        schema=Schema.from_descriptor(schema_descriptor),
-        detector=frictionless.Detector(schema_sync=True),
-        dialect=frictionless.Dialect(header_case=False),
-    )
-    report = frictionless.validate(resource)
-    assert report.valid
+    # resource = TableResource(
+    #     source=[["a"], ["foo"]],
+    #     schema=Schema.from_descriptor(schema_descriptor),
+    #     detector=frictionless.Detector(schema_sync=True),
+    #     dialect=frictionless.Dialect(header_case=False),
+    # )
+    # report = frictionless.validate(resource)
+    # assert report.valid

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -47,11 +47,11 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
             "nb_errors": 1,
             "types_errors_expected": ["missing-label"],
         },
-        # {
-        #     "constraints": {},
-        #     "nb_errors": 1,
-        #     "types_errors_expected": ["missing-label"],
-        # },
+        {
+            "constraints": {},
+            "nb_errors": 1,
+            "types_errors_expected": ["missing-label"],
+        },
     ]
 
     for tc in test_cases:

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -76,33 +76,27 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
             assert error.type == type_expected
 
     # Ignore header_case
-    schema_descriptor = {
-        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-        "fields": [{"name": "A"}],
-        "primaryKey": ["A"],
-    }
+    test_cases = [
+        {
+            "constraints": {"required": True},
+        },
+        {
+            "constraints": {},
+        },
+    ]
 
-    resource = TableResource(
-        source=[["a"], ["foo"]],
-        schema=Schema.from_descriptor(schema_descriptor),
-        detector=frictionless.Detector(schema_sync=True),
-        dialect=frictionless.Dialect(header_case=False),
-    )
-    report = frictionless.validate(resource)
-    assert report.valid
-    
-    # TODO to solve this test case needs to merge with working branch Fix-1635-...
-    schema_descriptor = {
-        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-        "fields": [{"name": "A", "constraints": {"required": True}}],
-        "primaryKey": ["A"],
-    }
+    for tc in test_cases:
+        schema_descriptor = {
+            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+            "fields": [{"name": "A", "constraints": tc["constraints"]}],
+            "primaryKey": ["A"],
+        }
 
-    resource = TableResource(
-        source=[["a"], ["foo"]],
-        schema=Schema.from_descriptor(schema_descriptor),
-        detector=frictionless.Detector(schema_sync=True),
-        dialect=frictionless.Dialect(header_case=False),
-    )
-    report = frictionless.validate(resource)
-    assert report.valid
+        resource = TableResource(
+            source=[["a"], ["foo"]],
+            schema=Schema.from_descriptor(schema_descriptor),
+            detector=frictionless.Detector(schema_sync=True),
+            dialect=frictionless.Dialect(header_case=False),
+        )
+        report = frictionless.validate(resource)
+        assert report.valid

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -60,3 +60,22 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
     assert len(report.tasks[0].errors) == 1
     assert report.tasks[0].errors[0].type == "missing-label"
     assert not report.valid
+
+    schema_descriptor = {
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [{"name": "A"}],
+        "primaryKey": ["A"],
+    }
+
+    source = [["B"], ["foo"]]
+
+    resource = TableResource(
+        source,
+        schema=Schema.from_descriptor(schema_descriptor),
+        detector=frictionless.Detector(schema_sync=True),
+    )
+
+    report = frictionless.validate(resource)
+    print(report)
+    assert report.tasks[0].errors[0].type == "primary-key"
+    assert not report.valid

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -41,18 +41,17 @@ def test_missing_label():
 
 
 def test_missing_primary_key_label_with_shema_sync_issue_1633():
-
     test_cases = [
         {
             "constraints": {"required": True},
-            "nb_errors": 2,
-            "types_errors_expected": ["missing-label", "primary-key"],
-        },
-        {
-            "constraints": {},
             "nb_errors": 1,
-            "types_errors_expected": ["primary-key"],
-        }
+            "types_errors_expected": ["missing-label"],
+        },
+        # {
+        #     "constraints": {},
+        #     "nb_errors": 1,
+        #     "types_errors_expected": ["missing-label"],
+        # },
     ]
 
     for tc in test_cases:
@@ -78,16 +77,16 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
 
     # Ignore header_case
     schema_descriptor = {
-            "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-            "fields": [{"name": "A"}],
-            "primaryKey": ["A"],
-        }
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [{"name": "A"}],
+        "primaryKey": ["A"],
+    }
 
     resource = TableResource(
         source=[["a"], ["foo"]],
         schema=Schema.from_descriptor(schema_descriptor),
         detector=frictionless.Detector(schema_sync=True),
-        dialect=frictionless.Dialect(header_case=False)
+        dialect=frictionless.Dialect(header_case=False),
     )
     report = frictionless.validate(resource)
     assert report.valid

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -75,18 +75,18 @@ def test_missing_primary_key_label_with_shema_sync_issue_1633():
         for error, type_expected in zip(errors, tc["types_errors_expected"]):
             assert error.type == type_expected
 
-    # # Ignore header_case
-    # schema_descriptor = {
-    #     "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
-    #     "fields": [{"name": "A", "constraints": {"required": True}}],
-    #     "primaryKey": ["A"],
-    # }
+    # Ignore header_case
+    schema_descriptor = {
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [{"name": "A", "constraints": {"required": True}}],
+        "primaryKey": ["A"],
+    }
 
-    # resource = TableResource(
-    #     source=[["a"], ["foo"]],
-    #     schema=Schema.from_descriptor(schema_descriptor),
-    #     detector=frictionless.Detector(schema_sync=True),
-    #     dialect=frictionless.Dialect(header_case=False),
-    # )
-    # report = frictionless.validate(resource)
-    # assert report.valid
+    resource = TableResource(
+        source=[["a"], ["foo"]],
+        schema=Schema.from_descriptor(schema_descriptor),
+        detector=frictionless.Detector(schema_sync=True),
+        dialect=frictionless.Dialect(header_case=False),
+    )
+    report = frictionless.validate(resource)
+    assert report.valid

--- a/frictionless/validator/__spec__/resource/test_schema.py
+++ b/frictionless/validator/__spec__/resource/test_schema.py
@@ -378,10 +378,10 @@ def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_16
     schema_descriptor_3 = {
         "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
         "fields": [
-                {"name": "Aa", "constraints": {"required": True}},
-                {"name": "BB", "constraints": {"required": True}},
-                {"name": "cc"}
-            ]
+            {"name": "Aa", "constraints": {"required": True}},
+            {"name": "BB", "constraints": {"required": True}},
+            {"name": "cc"},
+        ],
     }
     schema = Schema.from_descriptor(schema_descriptor_3)
     source = [["bb", "CC"], ["foo", "bar"]]
@@ -389,7 +389,7 @@ def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_16
         source,
         schema=schema,
         detector=Detector(schema_sync=True),
-        dialect=Dialect(header_case=False)
+        dialect=Dialect(header_case=False),
     )
     assert not report.valid
     # Expect one single error misisng-label related to missing column 'Aa'

--- a/frictionless/validator/__spec__/resource/test_schema.py
+++ b/frictionless/validator/__spec__/resource/test_schema.py
@@ -391,31 +391,30 @@ def test_validate_resource_ignoring_header_case_issue_1635():
                 "type": "string",
                 "constraints": {"required": True},
             },
-            {"name": "CC", "title": "Field C", "type": "string"},
         ],
     }
 
     test_cases = [
         {
-            "source": [["AA", "bb", "cc"], ["a", "b", "c"]],
-            "dialect": Dialect(header_case=False),
+            "source": [["AA", "bb"], ["a", "b"]],
+            "header_case": False,
             "expected_valid_report": True,
             "expected_flattened_report": [],
         },
         {
-            "source": [["AA", "bb", "cc"], ["a", "b", "c"]],
-            "dialect": Dialect(header_case=True),
+            "source": [["AA", "bb"], ["a", "b"]],
+            "header_case": True,
             "expected_valid_report": False,
             "expected_flattened_report": [
-                [None, 4, "aa", "missing-label"],
-                [None, 5, "BB", "missing-label"],
+                [None, 3, "aa", "missing-label"],
+                [None, 4, "BB", "missing-label"],
             ],
         },
         {
-            "source": [["bb", "CC"], ["foo", "bar"]],
-            "dialect": Dialect(header_case=False),
+            "source": [["bb"], ["foo"]],
+            "header_case": False,
             "expected_valid_report": False,
-            "expected_flattened_report": [[None, 3, "aa", "missing-label"]],
+            "expected_flattened_report": [[None, 2, "aa", "missing-label"]],
         },
     ]
 
@@ -424,7 +423,7 @@ def test_validate_resource_ignoring_header_case_issue_1635():
             tc["source"],
             schema=Schema.from_descriptor(schema_descriptor),
             detector=Detector(schema_sync=True),
-            dialect=tc["dialect"],
+            dialect=Dialect(header_case=tc["header_case"]),
         )
         report = frictionless.validate(resource)
         assert report.valid == tc["expected_valid_report"]

--- a/frictionless/validator/__spec__/resource/test_schema.py
+++ b/frictionless/validator/__spec__/resource/test_schema.py
@@ -317,7 +317,7 @@ def test_resource_validate_less_actual_fields_with_required_constraint_issue_950
 
 
 def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_1611():
-    schema_descriptor_1 = {
+    schema_A_required = {
         "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
         "fields": [
             {
@@ -331,20 +331,20 @@ def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_16
         ],
     }
 
-    schema_descriptor_2 = deepcopy(schema_descriptor_1)
+    schema_AC_required = deepcopy(schema_A_required)
     # Add required constraint on "C" field
-    schema_descriptor_2["fields"][2]["constraints"] = {"required": True}
+    schema_AC_required["fields"][2]["constraints"] = {"required": True}
 
     test_cases = [
         {
-            "schema": schema_descriptor_1,
+            "schema": schema_A_required,
             "source": [["B", "C"], ["b", "c"]],
             "expected_flattened_report": [
                 [None, 3, "A", "missing-label"],
             ],
         },
         {
-            "schema": schema_descriptor_2,
+            "schema": schema_AC_required,
             "source": [["B"], ["b"]],
             "expected_flattened_report": [
                 [None, 2, "A", "missing-label"],
@@ -352,7 +352,7 @@ def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_16
             ],
         },
         {
-            "schema": schema_descriptor_2,
+            "schema": schema_AC_required,
             "source": [
                 ["A", "B"],
                 ["a", "b"],
@@ -369,12 +369,15 @@ def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_16
             ],
         },
     ]
+
     for tc in test_cases:
         schema = Schema.from_descriptor(tc["schema"])
         resource = TableResource(
             tc["source"], schema=schema, detector=Detector(schema_sync=True)
         )
+
         report = frictionless.validate(resource)
+
         assert (
             report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])
             == tc["expected_flattened_report"]

--- a/frictionless/validator/__spec__/resource/test_schema.py
+++ b/frictionless/validator/__spec__/resource/test_schema.py
@@ -369,11 +369,33 @@ def test_resource_with_missing_required_header_with_schema_sync_is_true_issue_16
             tc["source"], schema=schema, detector=Detector(schema_sync=True)
         )
         report = frictionless.validate(resource)
-        print(report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"]))
         assert (
             report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])
             == tc["expected_flattened_report"]
         )
+
+    # Ignore case
+    schema_descriptor_3 = {
+        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+        "fields": [
+                {"name": "Aa", "constraints": {"required": True}},
+                {"name": "BB", "constraints": {"required": True}},
+                {"name": "cc"}
+            ]
+    }
+    schema = Schema.from_descriptor(schema_descriptor_3)
+    source = [["bb", "CC"], ["foo", "bar"]]
+    report = frictionless.validate(
+        source,
+        schema=schema,
+        detector=Detector(schema_sync=True),
+        dialect=Dialect(header_case=False)
+    )
+    assert not report.valid
+    # Expect one single error misisng-label related to missing column 'Aa'
+    assert (report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])) == [
+        [None, 3, "Aa", "missing-label"]
+    ]
 
 
 def test_validate_resource_ignoring_header_case_issue_1635():

--- a/frictionless/validator/__spec__/resource/test_schema.py
+++ b/frictionless/validator/__spec__/resource/test_schema.py
@@ -392,18 +392,23 @@ def test_validate_resource_ignoring_header_case_issue_1635():
     }
 
     source = [["aa", "bb", "cc"], ["a", "b", "c"]]
+
+    schema = Schema.from_descriptor(schema_descriptor)
+    
+    detector = Detector(schema_sync=True)
+
     report = frictionless.validate(
-        source=source,
-        schema=Schema.from_descriptor(schema_descriptor),
-        detector=Detector(schema_sync=True),
+        source,
+        schema=schema,
+        detector=detector,
         dialect=Dialect(header_case=False)
     )
     assert report.valid
 
     report = frictionless.validate(
-        source=source,
-        schema=Schema.from_descriptor(schema_descriptor),
-        detector=Detector(schema_sync=True)
+        source,
+        schema=schema,
+        detector=detector,
     )
     assert not report.valid
     assert (report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])) == [[None, 4, "AA", "missing-label"]]

--- a/frictionless/validator/__spec__/resource/test_schema.py
+++ b/frictionless/validator/__spec__/resource/test_schema.py
@@ -3,8 +3,14 @@ from copy import deepcopy
 import pytest
 
 import frictionless
-from frictionless import Checklist, Detector, Dialect, FrictionlessException, Schema
-from frictionless import fields
+from frictionless import (
+    Checklist,
+    Detector,
+    Dialect,
+    FrictionlessException,
+    Schema,
+    fields,
+)
 from frictionless.resources import TableResource
 
 # General

--- a/frictionless/validator/__spec__/resource/test_schema.py
+++ b/frictionless/validator/__spec__/resource/test_schema.py
@@ -3,8 +3,8 @@ from copy import deepcopy
 import pytest
 
 import frictionless
-from frictionless import Checklist, Detector, FrictionlessException, Schema, fields
-from frictionless import Dialect
+from frictionless import Checklist, Detector, Dialect, FrictionlessException, Schema
+from frictionless import fields
 from frictionless.resources import TableResource
 
 # General
@@ -394,14 +394,11 @@ def test_validate_resource_ignoring_header_case_issue_1635():
     source = [["aa", "bb", "cc"], ["a", "b", "c"]]
 
     schema = Schema.from_descriptor(schema_descriptor)
-    
+
     detector = Detector(schema_sync=True)
 
     report = frictionless.validate(
-        source,
-        schema=schema,
-        detector=detector,
-        dialect=Dialect(header_case=False)
+        source, schema=schema, detector=detector, dialect=Dialect(header_case=False)
     )
     assert report.valid
 
@@ -411,4 +408,6 @@ def test_validate_resource_ignoring_header_case_issue_1635():
         detector=detector,
     )
     assert not report.valid
-    assert (report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])) == [[None, 4, "AA", "missing-label"]]
+    assert (report.flatten(["rowNumber", "fieldNumber", "fieldName", "type"])) == [
+        [None, 4, "AA", "missing-label"]
+    ]


### PR DESCRIPTION
- fixes #1633 
- fixes #1635 
---
This PR fixes unexpected `missing-label` error in validation report which occurs when validating tabular data in this specific case (#1635): The data contains a named column corresponding to a required field in the schema used for validation, written without respecting case-sensitivity.
For example:
```
data = [["aa", "BB"], ["a", "b"]]
schema = {
        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
        "fields": [
            {"name": "AA", "constraints": {"required": True}},
            {"name": "bb", "constraints": {"required": True}}
        ]
    }
```
It adds some test cases: 
- one test case to ensure that validating this tabular data with this schema and using `schema_sync=True` and `dialect=Dialect(header_case=False)` options, returns a valid report.
- one test case to ensure that if validation is case-sensitive, if a name column does not respect case a missing-label occurs in validation report.
- another test case to ensure that validating with missing required column "AA" with this schema and using `schema_sync=True` and `dialect=Dialect(header_case=False)` options, returns an invalid report with `missing-label` error related to field "AA".

This PR also fixes unexpected KeyError raised when a primary key used in shema is missing in the tabular data to validate(#1633).
For example:
```
data = [["B"], ["b"]]
schema = {
        "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
        "fields": [
            {"name": "A"},
            {"name": "B"}
        ],
        "primaryKey": ["A"]
    }
```
It adds some test cases: 
- two test cases to ensure that when a label related to the schema primary key is missing, the validation report is invalid with single missing-label error:
   - a test case with the schema containing the primary key field not specified as 'required' 
   - a test case with the schema containing the primary key field specified as 'required'
- a test case to deal with insensitivity case in the data label corresponding to the primary key schema field: the validation report is valid

Finally, I suggest some refactoring in this PR:
- refactoring removing missing required label from field info refactoring removing missing required label from field info
- refactoring creating schema fields among labels part when using `schema_sync` option in `detect_schema()` `Detector` method
- refactoring to introduce intermediary `TableResource` methods to create `cells` related to primary key schema.
