### PR TITLE
chore: modernize ruff config to work with ruff >= v0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,12 +122,12 @@ docs = [
   "livemark build",
 ]
 format = [
-  "ruff frictionless tests --fix",
+  "ruff check frictionless tests --fix",
   "isort frictionless tests",
   "black frictionless tests",
 ]
 lint = [
-  "ruff frictionless tests",
+  "ruff check frictionless tests",
   "isort frictionless tests --check",
   "black frictionless tests --check",
   "pyright frictionless tests",
@@ -162,9 +162,11 @@ multi_line_output = 9
 
 [tool.ruff]
 line-length = 90
+
+[tool.ruff.lint]
 ignore = ["E501", "E731", "F405"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This PR modernizes the ruff configuration to work with ruff >= v0.2.

It gets rid of these warnings:

```
$ ruff frictionless tests
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
```

and

```
$ ruff frictionless tests
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```