### PR TITLE
Fix deprecated lazy_fixture imports

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -19,6 +19,7 @@ jobs:
     if: github.event_name != 'schedule' || github.repository_owner == 'frictionlessdata'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:

--- a/frictionless/formats/pandas/parser.py
+++ b/frictionless/formats/pandas/parser.py
@@ -157,7 +157,7 @@ class PandasParser(Parser):
                     # http://pandas.pydata.org/pandas-docs/stable/gotchas.html#support-for-integer-na
                     if value is None and field.type in ("number", "integer"):
                         fixed_types[field.name] = "number"
-                        value = np.NaN
+                        value = np.nan
                     if field.name in source.schema.primary_key:
                         index_values.append(value)
                     else:

--- a/frictionless/indexer/__spec__/test_resource.py
+++ b/frictionless/indexer/__spec__/test_resource.py
@@ -1,8 +1,8 @@
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
 from frictionless import formats, platform
 from frictionless.resources import TableResource
-from pytest_lazyfixture import lazy_fixture
 
 control = formats.sql.SqlControl(table="table")
 fast_database_urls = [

--- a/frictionless/indexer/__spec__/test_resource.py
+++ b/frictionless/indexer/__spec__/test_resource.py
@@ -2,18 +2,19 @@ import pytest
 
 from frictionless import formats, platform
 from frictionless.resources import TableResource
+from pytest_lazyfixture import lazy_fixture
 
 control = formats.sql.SqlControl(table="table")
 fast_database_urls = [
-    pytest.lazy_fixtures("sqlite_url"),
-    pytest.lazy_fixtures("postgresql_url"),
+    lazy_fixture("sqlite_url"),
+    lazy_fixture("postgresql_url"),
 ]
 database_urls = fast_database_urls + [
-    pytest.lazy_fixtures("mysql_url"),
+    lazy_fixture("mysql_url"),
 ]
 if platform.type != "windows":
     database_urls += [
-        pytest.lazy_fixtures("duckdb_url"),
+        lazy_fixture("duckdb_url"),
     ]
 pytestmark = pytest.mark.skipif(
     platform.type == "darwin" or platform.type == "windows",

--- a/frictionless/indexer/__spec__/test_resource.py
+++ b/frictionless/indexer/__spec__/test_resource.py
@@ -1,20 +1,20 @@
 import pytest
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazy_fixtures import lf
 
 from frictionless import formats, platform
 from frictionless.resources import TableResource
 
 control = formats.sql.SqlControl(table="table")
 fast_database_urls = [
-    lazy_fixture("sqlite_url"),
-    lazy_fixture("postgresql_url"),
+    lf("sqlite_url"),
+    lf("postgresql_url"),
 ]
 database_urls = fast_database_urls + [
-    lazy_fixture("mysql_url"),
+    lf("mysql_url"),
 ]
 if platform.type != "windows":
     database_urls += [
-        lazy_fixture("duckdb_url"),
+        lf("duckdb_url"),
     ]
 pytestmark = pytest.mark.skipif(
     platform.type == "darwin" or platform.type == "windows",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ dev = [
     "pytest-cov",
     "pytest-vcr",
     "pytest-mock",
-    "pytest-only",
     "oauth2client",
     "requests-mock",
     "pytest-dotenv",


### PR DESCRIPTION
This PR fixes several deprecations that were making our tests fail.

I'm also removing `pytest-only` dependency since it does not support Python 3.12 and we are not currently using it.


---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
