### PR TITLE
fix: missing checklist argument for validating resource

### DIFF
--- a/frictionless/validator/__spec__/package/test_checklist.py
+++ b/frictionless/validator/__spec__/package/test_checklist.py
@@ -1,0 +1,23 @@
+import json
+
+from frictionless import Checklist, Package
+
+
+def test_package_validate_with_skip_errors():
+    ## Test runs on data with two blank-row errors, one primary-key error, see
+    # first test case
+    test_cases = [
+        {"ignore": [], "expect_errors": ["blank-row", "primary-key", "blank-row"]},
+        {"ignore": ["primary-key"], "expect_errors": ["blank-row", "blank-row"]},
+        {"ignore": ["blank-row"], "expect_errors": ["primary-key"]},
+        {"ignore": ["blank-row", "primary-key"], "expect_errors": []},
+    ]
+
+    for tc in test_cases:
+        with open("data/invalid/datapackage.json") as file:
+            package = Package(json.load(file), basepath="data/invalid")
+            checklist = Checklist(skip_errors=tc["ignore"])
+
+            report = package.validate(checklist)
+
+            assert report.flatten(["type"]) == [[t] for t in tc["expect_errors"]]

--- a/frictionless/validator/validator.py
+++ b/frictionless/validator/validator.py
@@ -48,6 +48,7 @@ class Validator:
         if not parallel or with_fks:
             for resource in resources:
                 report = resource.validate(
+                    checklist=checklist,
                     limit_errors=limit_errors,
                     limit_rows=limit_rows,
                 )


### PR DESCRIPTION
Very important and simple fix to make sure the skip_errors, and overall checklist are passed down to resource.validate calls

Fixes #1639 
