### PR TITLE
fix: remote xlsx file reading with python 3.12

### DIFF
--- a/frictionless/formats/excel/parsers/xlsx.py
+++ b/frictionless/formats/excel/parsers/xlsx.py
@@ -64,7 +64,8 @@ class XlsxParser(Parser):
                 target = tempfile.NamedTemporaryFile(delete=delete)
                 shutil.copyfileobj(loader.byte_stream, target)
                 target.seek(0)
-            if not target.delete:
+
+            if not delete:
                 control.workbook_cache[path] = target.name  # type: ignore
                 atexit.register(os.remove, target.name)
             # TODO: rebase on using resource without system?


### PR DESCRIPTION
- fixes #1642 

Adapt to changes of API of `_TemporaryFileWrapper` in python 3.12, unfortunately not intercepted by pyright (see issue for details). The fix does not rely on this class's API, as the value is already stored in a local variable.