### PR TITLE
fix: accept github urls longer than organization/repo segments

### DIFF
--- a/frictionless/portals/github/__spec__/test_adapter.py
+++ b/frictionless/portals/github/__spec__/test_adapter.py
@@ -4,7 +4,6 @@ import os
 import pytest
 
 from frictionless import Catalog, FrictionlessException, Package, platform, portals
-from frictionless.portals.github.plugin import GithubPlugin
 from frictionless.resources import TableResource
 
 OUTPUT_OPTIONS_WITH_DP_YAML = {
@@ -103,19 +102,6 @@ OUTPUT_OPTIONS_WITHOUT_DP = {
 
 
 # Read
-
-
-def test_github_plugin_parse_repo():
-    test_cases = [
-        "https://github.com/user/some-repo",
-        "https://github.com/user/some-repo/some-other-stuff",
-    ]
-
-    plugin = GithubPlugin()
-    for test_case in test_cases:
-        adapter = plugin.create_adapter(source=test_case)
-        assert adapter.control.user == "user"
-        assert adapter.control.repo == "some-repo"
 
 
 @pytest.mark.vcr

--- a/frictionless/portals/github/__spec__/test_adapter.py
+++ b/frictionless/portals/github/__spec__/test_adapter.py
@@ -6,6 +6,8 @@ import pytest
 from frictionless import Catalog, FrictionlessException, Package, platform, portals
 from frictionless.resources import TableResource
 
+pytestmark = pytest.mark.skip(reason="Cassetes for vcr need to be regenerated")
+
 OUTPUT_OPTIONS_WITH_DP_YAML = {
     "resources": [
         {

--- a/frictionless/portals/github/__spec__/test_adapter.py
+++ b/frictionless/portals/github/__spec__/test_adapter.py
@@ -4,10 +4,8 @@ import os
 import pytest
 
 from frictionless import Catalog, FrictionlessException, Package, platform, portals
+from frictionless.portals.github.plugin import GithubPlugin
 from frictionless.resources import TableResource
-
-# TODO: recover
-pytestmark = pytest.mark.skip(reason="Cassetes for vcr need to be regenerated")
 
 OUTPUT_OPTIONS_WITH_DP_YAML = {
     "resources": [
@@ -30,6 +28,7 @@ OUTPUT_OPTIONS_WITH_DP_YAML = {
         }
     ]
 }
+
 OUTPUT_OPTIONS_WITH_DP = {
     "name": "test-package",
     "resources": [
@@ -71,6 +70,7 @@ OUTPUT_OPTIONS_WITHOUT_DP_CSV = {
         },
     ],
 }
+
 OUTPUT_OPTIONS_WITHOUT_DP = {
     "name": "test-repo-without-datapackage",
     "resources": [
@@ -105,10 +105,25 @@ OUTPUT_OPTIONS_WITHOUT_DP = {
 # Read
 
 
+def test_github_plugin_parse_repo():
+    test_cases = [
+        "https://github.com/user/some-repo",
+        "https://github.com/user/some-repo/some-other-stuff",
+    ]
+
+    plugin = GithubPlugin()
+    for test_case in test_cases:
+        adapter = plugin.create_adapter(source=test_case)
+        assert adapter.control.user == "user"
+        assert adapter.control.repo == "some-repo"
+
+
 @pytest.mark.vcr
 def test_github_adapter_read(options_without_dp):
     url = options_without_dp.pop("url")
     package = Package(url)
+    print("here we are")
+    print(package.to_descriptor())
     assert package.to_descriptor() == OUTPUT_OPTIONS_WITHOUT_DP
     assert (
         package.resources[0].basepath

--- a/frictionless/portals/github/__spec__/test_plugin.py
+++ b/frictionless/portals/github/__spec__/test_plugin.py
@@ -1,0 +1,33 @@
+import pytest
+
+from frictionless import FrictionlessException
+from frictionless.portals.github.plugin import GithubControl, GithubPlugin
+
+
+def test_github_plugin_parse_repo():
+    test_cases = [
+        {"url": "https://github.com/user/some-repo"},
+        {"url": "https://github.com/user/some-repo/some-other-stuff"},
+        {
+            "url": "https://github.com/user/some-repo/some-stuff",
+            "control": GithubControl(user="user", repo="some-repo"),
+        },
+    ]
+
+    plugin = GithubPlugin()
+    for test_case in test_cases:
+        control = test_case["control"] if "control" in test_case else None
+
+        adapter = plugin.create_adapter(source=test_case["url"], control=control)
+
+        assert adapter.control.user == "user"
+        assert adapter.control.repo == "some-repo"
+
+
+def test_github_url_control_mismatch():
+    url = "https://github.com/user/some-repo"
+    control = GithubControl(user="wrong-user")
+
+    plugin = GithubPlugin()
+    with pytest.raises(FrictionlessException):
+        plugin.create_adapter(source=url, control=control)

--- a/frictionless/portals/github/__spec__/test_plugin.py
+++ b/frictionless/portals/github/__spec__/test_plugin.py
@@ -25,9 +25,18 @@ def test_github_plugin_parse_repo():
 
 
 def test_github_url_control_mismatch():
-    url = "https://github.com/user/some-repo"
-    control = GithubControl(user="wrong-user")
+    test_cases = [
+        {
+            "url": "https://github.com/user/some-repo",
+            "control": GithubControl(user="wrong-user"),
+        },
+        {
+            "url": "https://github.com/user/some-repo",
+            "control": GithubControl(repo="wrong-repo"),
+        },
+    ]
 
-    plugin = GithubPlugin()
-    with pytest.raises(FrictionlessException):
-        plugin.create_adapter(source=url, control=control)
+    for test_case in test_cases:
+        plugin = GithubPlugin()
+        with pytest.raises(FrictionlessException):
+            plugin.create_adapter(source=test_case["url"], control=test_case["control"])

--- a/frictionless/portals/github/adapter.py
+++ b/frictionless/portals/github/adapter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from ...catalog import Catalog, Dataset
 from ...exception import FrictionlessException
@@ -12,16 +12,12 @@ from ...system import Adapter, PublishResult
 from .control import GithubControl
 
 if TYPE_CHECKING:
-    from github.AuthenticatedUser import AuthenticatedUser
     from github.ContentFile import ContentFile
-    from github.NamedUser import NamedUser
     from github.Repository import Repository
 
 
 class GithubAdapter(Adapter):
     """Read and write data from/to Github"""
-
-    client: Optional[GithubClient] = None
 
     def __init__(self, control: GithubControl):
         self.control = control
@@ -34,12 +30,7 @@ class GithubAdapter(Adapter):
             raise FrictionlessException(note)
 
         assert self.control.formats
-
-        if GithubAdapter.client:
-            client = GithubAdapter.client
-        else:
-            client = platform.github.Github(self.control.apikey)
-
+        client = platform.github.Github(self.control.apikey)
         location = "/".join([self.control.user, self.control.repo])
         try:
             repository = client.get_repo(location)
@@ -207,6 +198,7 @@ class GithubAdapter(Adapter):
             client = platform.github.Github(
                 self.control.apikey, per_page=self.control.per_page
             )
+            #  user = client.get_user()
             repositories = client.search_repositories(query["q"], **options)
             if self.control.page:
                 repositories = repositories.get_page(self.control.page)
@@ -277,13 +269,3 @@ def get_package(
             resource = Resource(path=file.path)
             package.add_resource(resource)
     return package
-
-
-class GithubClient(Protocol):
-    def get_repo(self, location: str) -> Repository: ...
-
-    def get_user(self, user: str) -> NamedUser | AuthenticatedUser: ...
-
-    def search_repositories(
-        self, query: str, user: str, sort: str, order: str
-    ) -> List[Repository]: ...

--- a/frictionless/portals/github/control.py
+++ b/frictionless/portals/github/control.py
@@ -54,7 +54,7 @@ class GithubControl(Control):
     """The number of results per page. Default value is 30. Max value is 100."""
 
     repo: Optional[str] = None
-    """Name of the repo to read or write."""
+    """Name of the repository to read or write."""
 
     search: Optional[str] = None
     """Search query containing one or more search keywords and qualifiers to filter the repositories.
@@ -65,7 +65,7 @@ class GithubControl(Control):
     By default the results are sorted by best match in desc order."""
 
     user: Optional[str] = None
-    """username of the github account."""
+    """Owner of the repository (user or organisation)"""
 
     filename: Optional[str] = None
     """Custom data package file name while publishing the data. By default it will use 'datapackage.json'."""

--- a/frictionless/portals/github/plugin.py
+++ b/frictionless/portals/github/plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Tuple
 from urllib.parse import urlparse
 
+from ...exception import FrictionlessException
 from ...system import Plugin
 from .adapter import GithubAdapter
 from .control import GithubControl
@@ -30,7 +31,21 @@ class GithubPlugin(Plugin):
                 if parsed.netloc == "github.com":
                     control = control or GithubControl()
 
-                    control.user, control.repo = self._extract_user_and_repo(parsed.path)
+                    user, repo = self._extract_user_and_repo(parsed.path)
+
+                    if control.user and control.user != user:
+                        raise FrictionlessException(
+                            'Mismatch between url and provided "user" information'
+                        )
+
+                    control.user = user
+
+                    if control.repo and control.repo != repo:
+                        raise FrictionlessException(
+                            'Mismatch between url and provided "repo" information'
+                        )
+
+                    control.repo = repo
 
                     return GithubAdapter(control)
 

--- a/frictionless/portals/github/plugin.py
+++ b/frictionless/portals/github/plugin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 from urllib.parse import urlparse
 
 from ...system import Plugin
@@ -18,12 +18,12 @@ class GithubPlugin(Plugin):
 
     def create_adapter(
         self,
-        source: Any,
+        source: Optional[str],
         *,
         control: Optional[Control] = None,
         basepath: Optional[str] = None,
         packagify: bool = False,
-    ):
+    ) -> Optional[GithubAdapter]:
         if isinstance(source, str):
             parsed = urlparse(source)
             if not control or isinstance(control, GithubControl):
@@ -33,6 +33,7 @@ class GithubPlugin(Plugin):
                     control.user, control.repo = self._extract_user_and_repo(parsed.path)
 
                     return GithubAdapter(control)
+
         if source is None and isinstance(control, GithubControl):
             return GithubAdapter(control=control)
 

--- a/frictionless/portals/github/plugin.py
+++ b/frictionless/portals/github/plugin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 from urllib.parse import urlparse
 
 from ...system import Plugin
@@ -29,12 +29,9 @@ class GithubPlugin(Plugin):
             if not control or isinstance(control, GithubControl):
                 if parsed.netloc == "github.com":
                     control = control or GithubControl()
-                    splited_url = parsed.path.split("/")[1:]
-                    if len(splited_url) == 1:
-                        control.user = splited_url[0]
-                        return GithubAdapter(control)
-                    if len(splited_url) == 2:
-                        control.user, control.repo = splited_url
+
+                    control.user, control.repo = self._extract_user_and_repo(parsed.path)
+
                     return GithubAdapter(control)
         if source is None and isinstance(control, GithubControl):
             return GithubAdapter(control=control)
@@ -42,3 +39,12 @@ class GithubPlugin(Plugin):
     def select_control_class(self, type: Optional[str] = None):
         if type == "github":
             return GithubControl
+
+    @staticmethod
+    def _extract_user_and_repo(url_path: str) -> Tuple[Optional[str], Optional[str]]:
+        splitted_url = url_path.split("/")[1:]
+
+        user = splitted_url[0] if len(splitted_url) >= 1 else None
+        repo = splitted_url[1] if len(splitted_url) >= 2 else None
+
+        return (user, repo)

--- a/frictionless/portals/github/plugin.py
+++ b/frictionless/portals/github/plugin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Literal, Optional, Tuple
 from urllib.parse import urlparse
 
 from ...exception import FrictionlessException
@@ -33,18 +33,10 @@ class GithubPlugin(Plugin):
 
                     user, repo = self._extract_user_and_repo(parsed.path)
 
-                    if control.user and control.user != user:
-                        raise FrictionlessException(
-                            'Mismatch between url and provided "user" information'
-                        )
+                    self._assert_no_mismatch(user, control.user, "user")
+                    self._assert_no_mismatch(repo, control.repo, "repo")
 
                     control.user = user
-
-                    if control.repo and control.repo != repo:
-                        raise FrictionlessException(
-                            'Mismatch between url and provided "repo" information'
-                        )
-
                     control.repo = repo
 
                     return GithubAdapter(control)
@@ -64,3 +56,15 @@ class GithubPlugin(Plugin):
         repo = splitted_url[1] if len(splitted_url) >= 2 else None
 
         return (user, repo)
+
+    @staticmethod
+    def _assert_no_mismatch(
+        value: Optional[str],
+        control_value: Optional[str],
+        user_or_repo: Literal["user", "repo"],
+    ):
+        if value and control_value and control_value != value:
+            raise FrictionlessException(
+                f'Mismatch between url and provided "{user_or_repo}"'
+                f"information (in url: {value}), in control: {control_value}"
+            )


### PR DESCRIPTION
- fixes #1607 

It looks like reading user (or organization) and repository names for the [Github portal](https://framework.frictionlessdata.io/docs/portals/github.html) from the URL are faulty, as it was not expecting more than two URL segments.

I relaxed this constraint, and parsing user (or org) and repository names now work even if the URL continues.

I performed the manual test : 

```sh 
fricitonless validate https://github.com/DCMLab/dcml_corpora/releases/download/v2.1/dcml_corpora.datapackage.json
``` 
that seems to work. 

Additionnal thoughts : 
- all tests related to github portal are actually skipped ! [pytest.mark.skip doc](https://docs.pytest.org/en/latest/how-to/skipping.html#skip-all-test-functions-of-a-class-or-module)
- I added some tests to confirm the above behavior.
- Documentation code for github portal was not working because it was pointing to a non-existant repo. I changed it a little with another repo.