### PR TITLE
fix: github adapter only applies to URLs formatted as expected

### DIFF
--- a/frictionless/portals/github/plugin.py
+++ b/frictionless/portals/github/plugin.py
@@ -51,8 +51,8 @@ class GithubPlugin(Plugin):
 
         has_expected_format = (
             parsed_url.netloc == "github.com"
-            and len(splited_url) < 1
-            and len(splited_url) > 2
+            and len(splited_url) >= 1
+            and len(splited_url) <= 2
         )
 
         if has_expected_format:

--- a/frictionless/portals/github/plugin.py
+++ b/frictionless/portals/github/plugin.py
@@ -49,11 +49,13 @@ class GithubPlugin(Plugin):
         parsed_url = urlparse(source)
         splited_url = parsed_url.path.split("/")[1:]
 
-        if (
+        has_expected_format = (
             parsed_url.netloc == "github.com"
             and len(splited_url) < 1
             and len(splited_url) > 2
-        ):
+        )
+
+        if has_expected_format:
             control = control or GithubControl()
             control.user = splited_url[0]
 
@@ -61,10 +63,6 @@ class GithubPlugin(Plugin):
                 control.repo = splited_url[1]
 
             return GithubAdapter(control)
-
-        else:
-            # Url has not an expected format
-            return
 
     def select_control_class(self, type: Optional[str] = None):
         if type == "github":


### PR DESCRIPTION
- fixes part of #1607 

In the absence of other hints (e.g. a Controller object associated to another plugin), all URLs from `github.com`  were being processed by the `GithubPlugin`, to create a Github Data Portal adapter. 

With this PR, `GithubPlugin` only handles the URL if it has the expected format "https://github.com/user_or_org/repo", and "https://github.com/user_or_org", otherwise it is passed other to be treated as a plain URL.

I also made some refactorings along the way, to have more readable and less nested code. 

As tests github portal are currently skipped, I checked manually that I have not broken this functionality. 
