### PR TITLE
Fix documentation typos

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -101,7 +101,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install Python
+      - name: Install Pythonha
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
@@ -130,7 +130,7 @@ jobs:
         run: |
           echo '!**/*.html' >> .gitignore
           hatch run docs-build
-      - name: Publush to Github Pages
+      - name: Publish to Github Pages
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: site

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -101,7 +101,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install Pythonha
+      - name: Install Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/docs/guides/transforming-data.md
+++ b/docs/guides/transforming-data.md
@@ -157,7 +157,7 @@ Frictionless includes more than 40+ built-in transform steps. They are grouped b
 - row
 - cell
 
-See [Transform Steps](../steps/cell.md) for a list of all available steps. It is also possible to write custom transform steps: see the next section.
+See [Transform Steps](../steps/cell.html) for a list of all available steps. It is also possible to write custom transform steps: see the next section.
 
 ## Custom Steps
 

--- a/docs/guides/transforming-data.md
+++ b/docs/guides/transforming-data.md
@@ -53,7 +53,7 @@ cat transform.csv
 
 The high-level interface to transform data is a set of `transform` functions:
 - `transform`: detects the source type and transforms data accordingly
-- `reosurce.transform`: transforms a resource
+- `resource.transform`: transforms a resource
 - `package.transform`: transforms a package
 
 We'll see examples of these functions in the next few sections.


### PR DESCRIPTION
A number of typos in the documentation were incorrect resulting on poor user experience. In particular, the link to the types of steps was to a Markdown file instead of HTML. 
