### PR TITLE
fix(ci): adapt tests to changes in click 8.20

### DIFF
--- a/frictionless/console/__spec__/test_console.py
+++ b/frictionless/console/__spec__/test_console.py
@@ -12,7 +12,7 @@ runner = CliRunner()
 def test_console():
     result = runner.invoke(console)
     assert result.exit_code == 2
-    assert result.stdout.count("Usage")
+    assert result.output.count("Usage")
 
 
 def test_console_version():
@@ -30,4 +30,4 @@ def test_console_help():
 def test_console_error_bad_command():
     result = runner.invoke(console, "bad")
     assert result.exit_code == 2
-    assert result.stdout.count("No such command 'bad'")
+    assert result.output.count("No such command 'bad'")

--- a/frictionless/console/commands/__spec__/test_summary.py
+++ b/frictionless/console/commands/__spec__/test_summary.py
@@ -154,7 +154,6 @@ def test_console_summary_without_command(tmpdir):
 
 def test_console_summary_without_filepath():
     result = runner.invoke(console, "summary")
-    print(result.output)
     assert result.exit_code == 1
     assert result.output.strip() == 'Providing "source" is required'
 

--- a/frictionless/console/commands/__spec__/test_summary.py
+++ b/frictionless/console/commands/__spec__/test_summary.py
@@ -13,16 +13,16 @@ def test_console_summary_error_not_found():
     result = runner.invoke(console, "summary data/countriess.csv")
     assert result.exit_code == 1
     assert (
-        result.stdout.count("[scheme-error]")
-        and result.stdout.count("[Errno 2]")
-        and result.stdout.count("data/countriess.csv")
+        result.output.count("[scheme-error]")
+        and result.output.count("[Errno 2]")
+        and result.output.count("data/countriess.csv")
     )
 
 
 def test_console_summary_invalid():
     result = runner.invoke(console, "summary data/countries-invalid.yaml")
     assert result.exit_code == 1
-    assert result.stdout.count(
+    assert result.output.count(
         'Field is not valid: "required" should be set as "constraints.required"'
     )
 
@@ -154,8 +154,9 @@ def test_console_summary_without_command(tmpdir):
 
 def test_console_summary_without_filepath():
     result = runner.invoke(console, "summary")
+    print(result.output)
     assert result.exit_code == 1
-    assert result.stdout.strip() == 'Providing "source" is required'
+    assert result.output.strip() == 'Providing "source" is required'
 
 
 def test_console_summary_zipped_innerpath():


### PR DESCRIPTION

Adapt the tests to changes introduced in click 8.20.

The changes affect the stdout / stderr content  (see [changelog](https://github.com/pallets/click/blob/main/CHANGES.rst#version-820)). 
