### PR TITLE
use an authentic User-Agent

### DIFF
--- a/frictionless/settings.py
+++ b/frictionless/settings.py
@@ -54,11 +54,7 @@ DEFAULT_FLOAT_NUMBER = False
 DEFAULT_GROUP_CHAR = ""
 DEFAULT_DECIMAL_CHAR = "."
 DEFAULT_HTTP_HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/54.0.2840.87 Safari/537.36"
-    )
+    "User-Agent": "frictionless-py/" + VERSION
 }
 DEFAULT_FIELD_CANDIDATES = [
     {"type": "yearmonth"},


### PR DESCRIPTION
Use `frictionless-py` + version as the User-Agent instead of a faked one.

- fixes#1757
