### PR TITLE
docs: clarify parallel validation scope

### DIFF
--- a/docs/console/validate.md
+++ b/docs/console/validate.md
@@ -14,3 +14,7 @@ With `validate` command you can validate your tabular files (indivisual or the w
 ```bash script tabs=CLI
 frictionless validate table.csv invalid.csv
 ```
+
+The `--parallel` option enables multiprocessing for validation jobs that contain multiple
+independent resources or tasks, such as Data Packages and Inquiries. It does not split validation
+of a single file into multiple processes.

--- a/docs/framework/inquiry.md
+++ b/docs/framework/inquiry.md
@@ -30,7 +30,7 @@ Tasks in the Inquiry accept the same arguments written in camelCase as the corre
 frictionless validate capital.inquiry-example.yaml
 ```
 
-At first sight, it's no clear why such a construct exists but when your validation workflow gets complex, the Inquiry can provide a lot of flexibility and power. Last but not least, the Inquiry will use multiprocessing if there are more than 1 task provided.
+At first sight, it's no clear why such a construct exists but when your validation workflow gets complex, the Inquiry can provide a lot of flexibility and power. If the `parallel` flag is provided, Inquiry validation can use multiprocessing to run independent tasks concurrently; it does not split validation of a single file/resource across multiple processes.
 
 ## Reference
 

--- a/docs/guides/validating-data.md
+++ b/docs/guides/validating-data.md
@@ -176,6 +176,11 @@ print(report)
 
 As we can see, the result is in a similar format to what we have already seen, and shows errors as we expected: we have one invalid resource and one valid resource.
 
+> Package validation can use multiprocessing if the `parallel` flag is provided. This runs
+> independent resources in the package concurrently; it does not split validation of a single
+> file/resource across multiple processes. Parallel execution is also disabled when foreign keys
+> are used, because those checks can depend on multiple resources.
+
 ## Validating an Inquiry
 
 > The Inquiry is an advanced concept mostly used by software integrators. For example, under the hood, Frictionless Framework uses inquiries to implement client-server validation within the built-in API. Please skip this section if this information feels unnecessary for you.
@@ -208,7 +213,9 @@ print(report)
 
 At first sight, it might not be clear why such a construct exists, but when your validation workflow gets complex, the Inquiry can provide a lot of flexibility and power.
 
-> The Inquiry will use multiprocessing if there is the `parallel` flag provided. It might speed up your validation dramatically especially on a 4+ cores processor.
+> The Inquiry will use multiprocessing if there is the `parallel` flag provided. This runs
+> independent inquiry tasks concurrently; it does not split validation of a single file/resource
+> across multiple processes.
 
 ## Validation Report
 

--- a/frictionless/console/common.py
+++ b/frictionless/console/common.py
@@ -266,7 +266,7 @@ limit_rows = Option(
 
 parallel = Option(
     default=None,
-    help="Enable multiprocessing",
+    help="Enable multiprocessing for package/inquiry validation",
 )
 
 output_path = Option(

--- a/frictionless/resource/resource.py
+++ b/frictionless/resource/resource.py
@@ -611,7 +611,8 @@ class Resource(Metadata, metaclass=Factory):  # type: ignore
             checklist: a Checklist object
             name: limit validation to one resource (if applicable)
             on_row: callbacke for every row
-            paraller: allow parallel validation (multiprocessing)
+            parallel: accepted for API compatibility; resource validation itself
+                is not split across multiple processes
             limit_rows: limit amount of rows to this number
             limit_errors: limit amount of errors to this number
 


### PR DESCRIPTION
## Summary
- Clarify that `--parallel`/`parallel=True` runs independent Package resources or Inquiry tasks concurrently.
- Document that single-file/resource validation is not split across multiple processes.
- Tighten the CLI help and `Resource.validate` parameter docs to avoid implying single-resource multiprocessing.

Fixes #1721

## Test plan
- `python -m ruff check frictionless/console/common.py frictionless/resource/resource.py`
- `git diff --check`