### PR TITLE
Support csv format for ArrayField

### DIFF
--- a/docs/fields/array.md
+++ b/docs/fields/array.md
@@ -14,6 +14,16 @@ rows = extract(data, schema=Schema(fields=[fields.ArrayField(name='name')]))
 print(rows)
 ```
 
+Use `format="csv"` to read comma-separated array values.
+
+```python script tabs=Python
+from frictionless import Schema, extract, fields
+
+data = [["name"], ["value1, value2"]]
+rows = extract(data, schema=Schema(fields=[fields.ArrayField(name="name", format="csv")]))
+print(rows)
+```
+
 ## Reference
 
 ```yaml reference

--- a/frictionless/fields/__spec__/test_array.py
+++ b/frictionless/fields/__spec__/test_array.py
@@ -20,6 +20,12 @@ from frictionless import Field, Package, fields
         ("default", 1, None, {}),
         ("default", "3.14", None, {}),
         ("default", "", None, {}),
+        ("csv", "val1,val2", ["val1", "val2"], {}),
+        ("csv", "val1, val2", ["val1", "val2"], {}),
+        ("csv", '"val1,val2", val3', ["val1,val2", "val3"], {}),
+        ("csv", ["val1", "val2"], ["val1", "val2"], {}),
+        ("csv", ("val1", "val2"), ["val1", "val2"], {}),
+        ("csv", 1, None, {}),
     ],
 )
 def test_array_read_cell(format, source, target, options):
@@ -36,6 +42,13 @@ def test_array_read_cell(format, source, target, options):
 def test_array_read_cell_array_item():
     field = fields.ArrayField(name="name", array_item={"type": "integer"})
     cell, notes = field.read_cell('["1", "2", "3"]')
+    assert cell == [1, 2, 3]
+    assert notes is None
+
+
+def test_array_read_cell_array_item_csv():
+    field = fields.ArrayField(name="name", format="csv", array_item={"type": "integer"})
+    cell, notes = field.read_cell("1,2,3")
     assert cell == [1, 2, 3]
     assert notes is None
 

--- a/frictionless/fields/array.py
+++ b/frictionless/fields/array.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 from typing import Any, Dict, Optional
 
@@ -52,6 +53,17 @@ class ArrayField(Field):
                             notes[name] = f"array item {note}"
                     cell[index] = item_cell
             return cell, notes
+
+        if self.format == "csv":
+            def csv_cell_reader(cell: Any):
+                if isinstance(cell, str):
+                    try:
+                        cell = next(csv.reader([cell], skipinitialspace=True))
+                    except csv.Error:
+                        cell = None
+                return cell_reader(cell)
+
+            return csv_cell_reader
 
         return cell_reader
 


### PR DESCRIPTION
- fixes #1434

---

## Summary

- Add `format="csv"` support for `ArrayField`
- Parse CSV array values with Python's built-in `csv` module
- Add tests for CSV values, quoted commas, spaced delimiters, invalid values, and `array_item` conversion
- Add an ArrayField docs example for CSV format

## Tests

- `hatch run python -m pytest frictionless\fields\__spec__\test_array.py -q`
