### PR TITLE
fix: remove side effects from row.__str__ and row.__repr__

### DIFF
--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -216,7 +216,7 @@ class Detector:
             encoding = detector.result["encoding"] or settings.DEFAULT_ENCODING
             confidence = detector.result["confidence"] or 0
             if confidence < self.encoding_confidence:
-                # low confidence, so we try UTF8
+                # low confidence, so we try default encoding
                 # If decoding fails, we fallback to the detected encoding
                 # despite the low-confidence
                 detected = encoding

--- a/frictionless/table/row.py
+++ b/frictionless/table/row.py
@@ -52,12 +52,16 @@ class Row(Dict[str, Any]):
         return super().__eq__(other)
 
     def __str__(self):
-        self.__process()
-        return super().__str__()
+        s = ""
+        if not self.__processed:
+            s = "Unprocessed: "
+        return s + super().__str__()
 
     def __repr__(self):
-        self.__process()
-        return super().__repr__()
+        s = ""
+        if not self.__processed:
+            s = "Unprocessed: "
+        return s + super().__repr__()
 
     def __setitem__(self, key: str, value: Any):
         try:


### PR DESCRIPTION
# Problem 

row.__str__ and row.__repr__ were having side effects (processing the row before returning it). 

This has caused headaches to debug when printing the row at some point would change the behavior. 

# Correction

Remove the side effect

+ on the way correct a code comment