### PR TITLE
feat: accept DPv2 missing values object with labels.  

### DIFF
--- a/frictionless/schema/__init__.py
+++ b/frictionless/schema/__init__.py
@@ -1,3 +1,4 @@
 from .field import Field
+from .missing_values import MissingValue, MissingValues
 from .schema import Schema
 from .types import *

--- a/frictionless/schema/__spec__/field/test_read.py
+++ b/frictionless/schema/__spec__/field/test_read.py
@@ -43,3 +43,20 @@ def test_field_read_cell_number_missingValues():
     assert field.read_cell("NA") == (None, None)
     assert field.read_cell("N/A") == (None, None)
     assert field.read_cell(0) == (None, None)
+
+
+def test_field_read_cell_object_missingValues():
+    descriptor = {
+        "name": "name",
+        "type": "string",
+        "missingValues": [
+            {"value": "", "label": "OMITTED"},
+            {"value": "-99", "label": "REFUSED"},
+        ],
+    }
+    field = Field.from_descriptor(descriptor)
+    assert field.read_cell("") == (None, None)
+    assert field.read_cell("-99") == (None, None)
+    assert field.read_cell("x") == ("x", None)
+    # serialization stays lossless
+    assert field.to_descriptor()["missingValues"] == descriptor["missingValues"]

--- a/frictionless/schema/__spec__/test_missing_values.py
+++ b/frictionless/schema/__spec__/test_missing_values.py
@@ -1,0 +1,107 @@
+import pytest
+
+from frictionless.schema.missing_values import MissingValues
+
+# Read / query
+
+READ_CASES = [
+    # name, descriptor, value_strings, contains, not_contains, representation
+    (
+        "string-form",
+        ["", "NA", "N/A"],
+        ["", "NA", "N/A"],
+        ["", "NA", "N/A"],
+        ["x", "-"],
+        "",
+    ),
+    (
+        "object-form",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "", "label": "OMITTED"}],
+        ["-99", ""],
+        ["-99", ""],
+        ["x", "NA"],
+        "-99",
+    ),
+    (
+        "object-without-label",
+        [{"value": "-"}],
+        ["-"],
+        ["-"],
+        ["", "x"],
+        "-",
+    ),
+    (
+        # empty: no value converts to null, and the representation falls back
+        # to the spec default missing value ("")
+        "empty",
+        [],
+        [],
+        [],
+        ["", "x"],
+        "",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name, descriptor, value_strings, contains, not_contains, representation",
+    READ_CASES,
+    ids=[case[0] for case in READ_CASES],
+)
+def test_missing_values_query(
+    name, descriptor, value_strings, contains, not_contains, representation
+):
+    mv = MissingValues.from_descriptor(descriptor)
+    assert mv.value_strings() == value_strings
+    for value in contains:
+        assert value in mv
+    for value in not_contains:
+        assert value not in mv
+    assert mv.representation == representation
+
+
+# List-like interface (backward compatibility: consumers read List[str])
+
+LIST_LIKE_CASES = [
+    ("string-form", ["", "NA", "N/A"], ["", "NA", "N/A"]),
+    (
+        "object-form",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "", "label": "OMITTED"}],
+        ["-99", ""],
+    ),
+    ("empty", [], []),
+]
+
+
+@pytest.mark.parametrize(
+    "name, descriptor, expected",
+    LIST_LIKE_CASES,
+    ids=[case[0] for case in LIST_LIKE_CASES],
+)
+def test_missing_values_list_like(name, descriptor, expected):
+    mv = MissingValues.from_descriptor(descriptor)
+    assert mv == expected
+    assert list(mv) == expected
+    assert len(mv) == len(expected)
+    for index, value in enumerate(expected):
+        assert mv[index] == value
+
+
+# Serialization (lossless round-trip)
+
+ROUNDTRIP_CASES = [
+    ("string-form", ["", "NA"]),
+    ("object-form", [{"value": "-99", "label": "REFUSED"}]),
+    ("object-without-label", [{"value": "-"}]),
+    ("empty", []),
+]
+
+
+@pytest.mark.parametrize(
+    "name, descriptor",
+    ROUNDTRIP_CASES,
+    ids=[case[0] for case in ROUNDTRIP_CASES],
+)
+def test_missing_values_roundtrip(name, descriptor):
+    mv = MissingValues.from_descriptor(descriptor)
+    assert mv.to_descriptor() == descriptor

--- a/frictionless/schema/__spec__/test_missing_values.py
+++ b/frictionless/schema/__spec__/test_missing_values.py
@@ -1,5 +1,6 @@
 import pytest
 
+from frictionless import Field, FrictionlessException, Schema
 from frictionless.schema.missing_values import MissingValues
 
 # Read / query
@@ -105,3 +106,83 @@ ROUNDTRIP_CASES = [
 def test_missing_values_roundtrip(name, descriptor):
     mv = MissingValues.from_descriptor(descriptor)
     assert mv.to_descriptor() == descriptor
+
+
+# Validation (uniqueness of value and label)
+
+VALIDATION_CASES = [
+    ("valid-strings", ["", "NA"], []),
+    (
+        "valid-objects",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "", "label": "OMITTED"}],
+        [],
+    ),
+    (
+        "duplicate-value",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "-99", "label": "OMITTED"}],
+        ['missing value "-99" is not unique'],
+    ),
+    (
+        "duplicate-label",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "", "label": "REFUSED"}],
+        ['missing value label "REFUSED" is not unique'],
+    ),
+    (
+        "duplicate-value-and-label",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "-99", "label": "REFUSED"}],
+        [
+            'missing value "-99" is not unique',
+            'missing value label "REFUSED" is not unique',
+        ],
+    ),
+    (
+        # labels left out do not collide with each other
+        "missing-labels-do-not-collide",
+        [{"value": "-99"}, {"value": "-1"}],
+        [],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name, descriptor, expected",
+    VALIDATION_CASES,
+    ids=[case[0] for case in VALIDATION_CASES],
+)
+def test_missing_values_validation_notes(name, descriptor, expected):
+    mv = MissingValues.from_descriptor(descriptor)
+    assert mv.validation_notes() == expected
+
+
+# Validation surfaces through Field/Schema metadata validation
+
+
+def test_field_missing_values_duplicate_value_is_invalid():
+    with pytest.raises(FrictionlessException) as excinfo:
+        Field.from_descriptor(
+            {
+                "name": "name",
+                "type": "string",
+                "missingValues": [
+                    {"value": "-99", "label": "REFUSED"},
+                    {"value": "-99", "label": "OMITTED"},
+                ],
+            }
+        )
+    notes = [reason.note for reason in excinfo.value.reasons]
+    assert 'missing value "-99" is not unique' in notes
+
+
+def test_schema_missing_values_duplicate_label_is_invalid():
+    with pytest.raises(FrictionlessException) as excinfo:
+        Schema.from_descriptor(
+            {
+                "fields": [{"name": "name", "type": "string"}],
+                "missingValues": [
+                    {"value": "-99", "label": "REFUSED"},
+                    {"value": "", "label": "REFUSED"},
+                ],
+            }
+        )
+    notes = [reason.note for reason in excinfo.value.reasons]
+    assert 'missing value label "REFUSED" is not unique' in notes

--- a/frictionless/schema/field.py
+++ b/frictionless/schema/field.py
@@ -11,6 +11,7 @@ from .. import errors, settings
 from ..exception import FrictionlessException
 from ..metadata import Metadata
 from ..system import system
+from .missing_values import MISSING_VALUES_PROFILE, MissingValues
 
 if TYPE_CHECKING:
     from ..types import IDescriptor
@@ -50,12 +51,15 @@ class Field(Metadata):
     For example: "default","array" etc.
     """
 
-    missing_values: List[str] = attrs.field(
-        factory=settings.DEFAULT_MISSING_VALUES.copy
+    missing_values: MissingValues = attrs.field(
+        factory=lambda: MissingValues.from_descriptor(
+            settings.DEFAULT_MISSING_VALUES.copy()
+        ),
     )
     """
-    List of string values to be set as missing values in the field. If any of string in missing values
-    is found in the field value then it is set as None.
+    Values to be treated as missing values in the field. If any of them is found
+    in the field value then it is set as None. Accepts either the string form
+    (``["", "NA"]``) or the object form (``[{"value": "-99", "label": "REFUSED"}]``).
     """
 
     constraints: Dict[str, Any] = attrs.field(factory=dict)
@@ -92,6 +96,8 @@ class Field(Metadata):
         if name == "type":
             note = 'Use "schema.set_field_type()" to update the type of the field'
             raise FrictionlessException(errors.FieldError(note=note))
+        if name == "missing_values" and not isinstance(value, MissingValues):
+            value = MissingValues.from_descriptor(value)
         return super().__setattr__(name, value)  # type: ignore
 
     @property
@@ -168,12 +174,10 @@ class Field(Metadata):
         value_writer = self.create_value_writer()
 
         # Create missing value
-        try:
-            missing_value = self.missing_values[0]
-            if not self.has_defined("missing_values") and self.schema:
-                missing_value = self.schema.missing_values[0]
-        except IndexError:
-            missing_value = settings.DEFAULT_MISSING_VALUES[0]
+        missing_values = self.missing_values
+        if not self.has_defined("missing_values") and self.schema:
+            missing_values = self.schema.missing_values
+        missing_value = missing_values.representation
 
         # Create writer
         def cell_writer(cell: Any, *, ignore_missing: bool = False):
@@ -209,10 +213,7 @@ class Field(Metadata):
             "title": {"type": "string"},
             "description": {"type": "string"},
             "format": {"type": "string"},
-            "missingValues": {
-                "type": "array",
-                "items": {"type": "string"},
-            },
+            "missingValues": MISSING_VALUES_PROFILE,
             "constraints": {
                 "type": "object",
                 "properties": {
@@ -286,6 +287,12 @@ class Field(Metadata):
             if name in descriptor:
                 note = f'"{name}" should be set as "constraints.{name}"'
                 yield errors.FieldError(note=note)
+
+    def metadata_export(self, *, exclude: List[str] = []) -> IDescriptor:
+        descriptor = super().metadata_export(exclude=exclude)
+        if "missingValues" in descriptor:
+            descriptor["missingValues"] = self.missing_values.to_descriptor()
+        return descriptor
 
 
 # Internal

--- a/frictionless/schema/field.py
+++ b/frictionless/schema/field.py
@@ -282,6 +282,12 @@ class Field(Metadata):
                 )
                 yield errors.FieldError(note=note)
 
+        # Missing values
+        missing_values = descriptor.get("missingValues")
+        if missing_values is not None:
+            for note in MissingValues.from_descriptor(missing_values).validation_notes():
+                yield errors.FieldError(note=note)
+
         # Misleading
         for name in ["required"]:
             if name in descriptor:

--- a/frictionless/schema/missing_values.py
+++ b/frictionless/schema/missing_values.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Iterator, List, Optional, Union
+from typing import Any, Iterator, List, Optional, Sequence, Union
 
 import attrs
 from pydantic import BaseModel, ConfigDict
@@ -9,7 +9,7 @@ from .. import settings
 
 # Descriptor entries are either a plain string or an object with a value/label.
 # Per the datapackage spec the array is homogeneous: all strings OR all objects.
-IMissingValue = Union[str, dict[str, str]]
+IMissingValueEntry = Union[str, dict[str, str]]
 
 # JSON Schema profile shared by Field and Schema. The "anyOf" enforces the
 # homogeneity of the array (a mixed string/object array matches neither branch)
@@ -47,7 +47,7 @@ class MissingValue(BaseModel):
     label: Optional[str] = None
 
     @classmethod
-    def from_descriptor(cls, entry: IMissingValue) -> MissingValue:
+    def from_descriptor(cls, entry: IMissingValueEntry) -> MissingValue:
         if isinstance(entry, str):
             return cls(value=entry)
         return cls(**entry)
@@ -71,12 +71,27 @@ class MissingValues:
     as_objects: bool = False
 
     @classmethod
-    def from_descriptor(cls, descriptor: List[IMissingValue]) -> MissingValues:
+    def from_descriptor(cls, descriptor: Sequence[IMissingValueEntry]) -> MissingValues:
         as_objects = any(isinstance(entry, dict) for entry in descriptor)
         items = [MissingValue.from_descriptor(entry) for entry in descriptor]
         return cls(items=items, as_objects=as_objects)
 
-    def to_descriptor(self) -> List[IMissingValue]:
+    def validation_notes(self) -> List[str]:
+        """Notes describing why the collection is invalid (empty if valid).
+
+        Per the spec, each object entry must have a unique value and an
+        optional unique label. Labels left out do not collide with each other.
+        """
+        notes: List[str] = []
+        values = [item.value for item in self.items]
+        for value in _duplicates(values):
+            notes.append(f'missing value "{value}" is not unique')
+        labels = [item.label for item in self.items if item.label is not None]
+        for label in _duplicates(labels):
+            notes.append(f'missing value label "{label}" is not unique')
+        return notes
+
+    def to_descriptor(self) -> List[IMissingValueEntry]:
         if self.as_objects:
             return [item.model_dump(exclude_none=True) for item in self.items]
         return [item.value for item in self.items]
@@ -116,3 +131,14 @@ class MissingValues:
 
     def __contains__(self, cell: str) -> bool:
         return any(item.value == cell for item in self.items)
+
+
+def _duplicates(values: List[str]) -> List[str]:
+    """Values appearing more than once, each reported once in order."""
+    seen: set[str] = set()
+    duplicates: List[str] = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    return duplicates

--- a/frictionless/schema/missing_values.py
+++ b/frictionless/schema/missing_values.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any, Iterator, List, Optional, Union
+
+import attrs
+from pydantic import BaseModel, ConfigDict
+
+from .. import settings
+
+# Descriptor entries are either a plain string or an object with a value/label.
+# Per the datapackage spec the array is homogeneous: all strings OR all objects.
+IMissingValue = Union[str, dict[str, str]]
+
+# JSON Schema profile shared by Field and Schema. The "anyOf" enforces the
+# homogeneity of the array (a mixed string/object array matches neither branch)
+# and the uniqueness of the string entries. "anyOf" (rather than "oneOf") is
+# required because an empty array matches both branches. The uniqueness of
+# object "value" and "label" properties is checked in "metadata_validate".
+MISSING_VALUES_PROFILE = {
+    "anyOf": [
+        {
+            "type": "array",
+            "items": {"type": "string"},
+            "uniqueItems": True,
+        },
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["value"],
+                "properties": {
+                    "value": {"type": "string"},
+                    "label": {"type": "string"},
+                },
+            },
+        },
+    ],
+}
+
+
+class MissingValue(BaseModel):
+    """A single missing value with an optional human-readable label."""
+
+    model_config = ConfigDict(frozen=True)
+
+    value: str
+    label: Optional[str] = None
+
+    @classmethod
+    def from_descriptor(cls, entry: IMissingValue) -> MissingValue:
+        if isinstance(entry, str):
+            return cls(value=entry)
+        return cls(**entry)
+
+
+@attrs.frozen(eq=False)
+class MissingValues:
+    """A collection of missing values
+
+    Supports both the string form (``["", "NA"]``) and the object form
+    (``[{"value": "-99", "label": "REFUSED"}]``). Whether the collection
+    serializes back as strings or objects is a property of the collection
+    (the array is homogeneous), so a single ``as_objects`` flag preserves the
+    original form losslessly.
+
+    The collection is list-like over its value strings, so consumers that used
+    to read ``missing_values`` as a ``List[str]`` keep working unchanged.
+    """
+
+    items: List[MissingValue]
+    as_objects: bool = False
+
+    @classmethod
+    def from_descriptor(cls, descriptor: List[IMissingValue]) -> MissingValues:
+        as_objects = any(isinstance(entry, dict) for entry in descriptor)
+        items = [MissingValue.from_descriptor(entry) for entry in descriptor]
+        return cls(items=items, as_objects=as_objects)
+
+    def to_descriptor(self) -> List[IMissingValue]:
+        if self.as_objects:
+            return [item.model_dump(exclude_none=True) for item in self.items]
+        return [item.value for item in self.items]
+
+    def value_strings(self) -> List[str]:
+        return [item.value for item in self.items]
+
+    @property
+    def representation(self) -> str:
+        """The string written to represent a missing cell when serializing.
+
+        Falls back to the spec default missing value ("") when the collection
+        is empty.
+        """
+        if self.items:
+            return self.items[0].value
+        return settings.DEFAULT_MISSING_VALUES[0]
+
+    # List-like over value strings (backward compatibility)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, MissingValues):
+            return (self.items, self.as_objects) == (other.items, other.as_objects)
+        return self.value_strings() == other
+
+    def __hash__(self) -> int:
+        return hash((tuple(self.items), self.as_objects))
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.value_strings())
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __getitem__(self, index: int) -> str:
+        return self.value_strings()[index]
+
+    def __contains__(self, cell: str) -> bool:
+        return any(item.value == cell for item in self.items)

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -11,6 +11,7 @@ from ..metadata import Metadata
 from ..platform import platform
 from .factory import Factory
 from .field import Field
+from .missing_values import MISSING_VALUES_PROFILE, MissingValues
 from .types import INotes
 
 
@@ -62,10 +63,16 @@ class Schema(Metadata, metaclass=Factory):
     A List of fields in the schema.
     """
 
-    missing_values: List[str] = attrs.field(factory=settings.DEFAULT_MISSING_VALUES.copy)
+    missing_values: MissingValues = attrs.field(
+        factory=lambda: MissingValues.from_descriptor(
+            settings.DEFAULT_MISSING_VALUES.copy()
+        ),
+    )
     """
-    List of string values to be set as missing values in the schema fields. If any of string in
-    missing values is found in any of the field value then it is set as None.
+    Values to be treated as missing values in the schema fields. If any of them
+    is found in a field value then it is set as None. Accepts either the string
+    form (``["", "NA"]``) or the object form
+    (``[{"value": "-99", "label": "REFUSED"}]``).
     """
 
     primary_key: List[str] = attrs.field(factory=list)
@@ -82,6 +89,11 @@ class Schema(Metadata, metaclass=Factory):
         for field in self.fields:
             field.schema = self
         super().__attrs_post_init__()
+
+    def __setattr__(self, name: str, value: Any):  # type: ignore
+        if name == "missing_values" and not isinstance(value, MissingValues):
+            value = MissingValues.from_descriptor(value)
+        super().__setattr__(name, value)
 
     def __bool__(self):
         return bool(self.fields) or bool(self.to_descriptor())
@@ -292,10 +304,7 @@ class Schema(Metadata, metaclass=Factory):
             "title": {"type": "string"},
             "description": {"type": "string"},
             "fields": {"type": "array"},
-            "missingValues": {
-                "type": "array",
-                "items": {"type": "string"},
-            },
+            "missingValues": MISSING_VALUES_PROFILE,
             "primaryKey": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -386,3 +395,9 @@ class Schema(Metadata, metaclass=Factory):
                 note = 'foreign key fields "%s" does not match the reference fields "%s"'
                 note = note % (fk["fields"], fk["reference"]["fields"])
                 yield errors.SchemaError(note=note)
+
+    def metadata_export(self, *, exclude: List[str] = []) -> types.IDescriptor:
+        descriptor = super().metadata_export(exclude=exclude)
+        if "missingValues" in descriptor:
+            descriptor["missingValues"] = self.missing_values.to_descriptor()
+        return descriptor

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -396,6 +396,12 @@ class Schema(Metadata, metaclass=Factory):
                 note = note % (fk["fields"], fk["reference"]["fields"])
                 yield errors.SchemaError(note=note)
 
+        # Missing values
+        missing_values = descriptor.get("missingValues")
+        if missing_values is not None:
+            for note in MissingValues.from_descriptor(missing_values).validation_notes():
+                yield errors.SchemaError(note=note)
+
     def metadata_export(self, *, exclude: List[str] = []) -> types.IDescriptor:
         descriptor = super().metadata_export(exclude=exclude)
         if "missingValues" in descriptor:

--- a/frictionless/schema/types.py
+++ b/frictionless/schema/types.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Literal, Optional, Protocol, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Protocol, Tuple, Union
 
 from typing_extensions import Required, TypedDict
+
+
+class IMissingValue(TypedDict, total=False):
+    value: Required[str]
+    label: str
 
 
 class ISchema(TypedDict, total=False):
@@ -11,7 +16,7 @@ class ISchema(TypedDict, total=False):
     title: str
     description: str
     fields: Required[IField]
-    missingValues: List[str]
+    missingValues: List[Union[str, IMissingValue]]
     primary_key: List[str]
     foreign_keys: List[IForeignKey]
 
@@ -21,7 +26,7 @@ class IField(TypedDict, total=False):
     title: str
     description: str
     format: str
-    missingValues: List[str]
+    missingValues: List[Union[str, IMissingValue]]
 
 
 class IAnyField(IField, total=False):


### PR DESCRIPTION
https://datapackage.org/overview/changelog/#schemamissingvalues-updated


# TODO

- `MissingValues` class is currently a breaking change 
- Validation is always that of DP2 even for DP1 schema