### PR TITLE
feat: accept `$schema` property

### DIFF
--- a/frictionless/dialect/dialect.py
+++ b/frictionless/dialect/dialect.py
@@ -26,6 +26,12 @@ class Dialect(Metadata, metaclass=Factory):
     # TODO: add docs
     """
 
+    _schema_profile: Optional[str] = attrs.field(default=None, alias="schema_profile")
+    """
+    `$schema` property value, a JSON-schema profile URL this metadata follows.
+    See `Metadata._schema_profile`.
+    """
+
     name: Optional[str] = None
     """
     A short url-usable (and preferably human-readable) name.

--- a/frictionless/metadata/__spec__/test_metadata.py
+++ b/frictionless/metadata/__spec__/test_metadata.py
@@ -1,6 +1,6 @@
 import pytest
 
-from frictionless import Metadata, Package, Resource, Schema, settings
+from frictionless import Dialect, Metadata, Package, Resource, Schema, settings
 
 # General
 
@@ -63,8 +63,9 @@ SCHEMA_PROFILE = "https://datapackage.org/profiles/2.0/datapackage.json"
         (Package, {"resources": []}),
         (Schema, {"fields": []}),
         (Resource, {"name": "table", "path": "table.csv"}),
+        (Dialect, {}),
     ),
-    ids=["package", "schema", "resource"],
+    ids=["package", "schema", "resource", "dialect"],
 )
 def test_schema_profile_imported_from_descriptor(Entity, descriptor):
     metadata = Entity.from_descriptor({**descriptor, "$schema": SCHEMA_PROFILE})
@@ -79,8 +80,9 @@ def test_schema_profile_imported_from_descriptor(Entity, descriptor):
         (Package, {"resources": []}),
         (Schema, {"fields": []}),
         (Resource, {"name": "table", "path": "table.csv"}),
+        (Dialect, {}),
     ),
-    ids=["package", "schema", "resource"],
+    ids=["package", "schema", "resource", "dialect"],
 )
 def test_schema_profile_exported_to_descriptor(Entity, kwargs):
     metadata = Entity(schema_profile=SCHEMA_PROFILE, **kwargs)

--- a/frictionless/metadata/__spec__/test_metadata.py
+++ b/frictionless/metadata/__spec__/test_metadata.py
@@ -1,6 +1,6 @@
 import pytest
 
-from frictionless import Dialect, Metadata, Package, Resource, Schema, settings
+from frictionless import Dialect, Metadata, Package, Resource, Schema
 
 # General
 

--- a/frictionless/metadata/__spec__/test_metadata.py
+++ b/frictionless/metadata/__spec__/test_metadata.py
@@ -15,6 +15,7 @@ def test_metadata_from_path():
     assert descriptor["primaryKey"] == "id"
 
 
+<<<<<<< HEAD
 # @pytest.mark.parametrize(
 #     "Entity, descriptor",
 #     (
@@ -55,6 +56,8 @@ def test_metadata_from_path():
 SCHEMA_PROFILE = "https://datapackage.org/profiles/2.0/datapackage.json"
 
 
+=======
+>>>>>>> cc5edd81 (🔴 Infer datapackage version from $schema prop)
 @pytest.mark.parametrize(
     "Entity, descriptor",
     (
@@ -64,6 +67,7 @@ SCHEMA_PROFILE = "https://datapackage.org/profiles/2.0/datapackage.json"
     ),
     ids=["package", "schema", "resource"],
 )
+<<<<<<< HEAD
 def test_schema_profile_imported_from_descriptor(Entity, descriptor):
     metadata = Entity.from_descriptor({**descriptor, "$schema": SCHEMA_PROFILE})
     assert metadata._schema_profile == SCHEMA_PROFILE
@@ -83,3 +87,161 @@ def test_schema_profile_imported_from_descriptor(Entity, descriptor):
 def test_schema_profile_exported_to_descriptor(Entity, kwargs):
     metadata = Entity(schema_profile=SCHEMA_PROFILE, **kwargs)
     assert metadata.to_descriptor()["$schema"] == SCHEMA_PROFILE
+=======
+@pytest.mark.parametrize(
+    "schema, expected",
+    (
+        # Absent `$schema`: the spec mandates v1 as the default
+        (None, "v1"),
+        # Standard datapackage.org profiles: the version is read from the URL
+        ("https://datapackage.org/profiles/1.0/datapackage.json", "v1"),
+        ("https://datapackage.org/profiles/2.0/schema.json", "v2"),
+        ("https://datapackage.org/profiles/2.1/dataresource.json", "v2"),
+        # Custom profile: fall back to the default constant
+        (
+            "https://example.com/my-profile.json",
+            settings.DEFAULT_CUSTOM_PROFILE_DATAPACKAGE_VERSION,
+        ),
+    ),
+)
+def test_standard_version_inferred_from_schema(Entity, descriptor, schema, expected):
+    # Test only for direct inference from the class `$schema` property,
+    # not inheritance
+    descriptor = dict(descriptor)
+    if schema is not None:
+        descriptor["$schema"] = schema
+    metadata = Entity.from_descriptor(descriptor)
+    assert metadata.standard_version == expected
+
+
+# Inheritance from a parent entity
+#
+# When an entity is built as part of a parent (a resource inside a package),
+# the parent's resolved version always takes precedence over what the child
+# would infer on its own.
+
+V1 = "https://datapackage.org/profiles/1.0/datapackage.json"
+V2 = "https://datapackage.org/profiles/2.0/datapackage.json"
+
+
+@pytest.mark.parametrize(
+    "package_schema, resource_schema, expected",
+    (
+        # The parent wins, even with a misalignment, in whichever direction it goes
+        (V2, V1, "v2"),
+        (V1, V2, "v1"),
+        # A package without `$schema` resolves to v1 and imposes it
+        (None, V2, "v1"),
+        # The child's own version is used only when consistent with the parent
+        (V2, V2, "v2"),
+        (V2, None, "v2"),
+    ),
+)
+def test_resource_inherits_standard_version_from_package(
+    package_schema, resource_schema, expected
+):
+    resource = {"name": "table", "path": "table.csv"}
+    if resource_schema is not None:
+        resource["$schema"] = resource_schema
+    descriptor = {"resources": [resource]}
+    if package_schema is not None:
+        descriptor["$schema"] = package_schema
+    package = Package.from_descriptor(descriptor)
+    assert package.get_resource("table").standard_version == expected
+
+
+@pytest.mark.parametrize(
+    "resource_schema, schema_schema, expected",
+    (
+        (V2, V1, "v2"),
+        (V1, V2, "v1"),
+        (None, V2, "v1"),
+        (V2, None, "v2"),
+    ),
+)
+def test_schema_inherits_standard_version_from_resource(
+    resource_schema, schema_schema, expected
+):
+    schema = {"fields": [{"name": "a", "type": "string"}]}
+    if schema_schema is not None:
+        schema["$schema"] = schema_schema
+    descriptor = {"name": "table", "path": "table.csv", "schema": schema}
+    if resource_schema is not None:
+        descriptor["$schema"] = resource_schema
+    resource = Resource.from_descriptor(descriptor)
+    assert resource.schema.datapackage_version == expected
+
+
+# # Inheritance through imperative (post-construction) attribution
+# #
+# # The same rule must hold when entities are wired together programmatically,
+# # not only when built from a single descriptor. Inheritance is pushed down at
+# # attach time (no pull, no back-ref); re-parenting re-runs the push, so the
+# # child reflects its current parent. `basepath` rides the same mechanism.
+#
+#
+# def test_resource_inherits_when_added_to_package():
+#     resource = Resource.from_descriptor({"name": "t", "path": "t.csv", "$schema": V1})
+#     assert resource.standard_version == "v1"
+#     package = Package.from_descriptor({"$schema": V2, "resources": []})
+#     package.add_resource(resource)
+#     assert resource.standard_version == "v2"
+#
+#
+# def test_resource_reflects_current_package_on_reparent():
+#     resource = Resource.from_descriptor({"name": "t", "path": "t.csv", "$schema": V2})
+#     Package.from_descriptor({"$schema": V1, "resources": []}).add_resource(resource)
+#     assert resource.standard_version == "v1"
+#     Package.from_descriptor({"$schema": V2, "resources": []}).add_resource(resource)
+#     assert resource.standard_version == "v2"
+#
+#
+# def test_schema_inherits_when_assigned_to_resource():
+#     schema = Schema.from_descriptor(
+#         {"$schema": V1, "fields": [{"name": "a", "type": "string"}]}
+#     )
+#     assert schema.standard_version == "v1"
+#     resource = Resource.from_descriptor({"name": "t", "path": "t.csv", "$schema": V2})
+#     resource.schema = schema
+#     assert resource.schema.standard_version == "v2"
+#
+#
+# def test_schema_from_separate_file_inherits_from_resource(tmp_path):
+#     (tmp_path / "schema.json").write_text(
+#         json.dumps({"$schema": V1, "fields": [{"name": "a", "type": "string"}]})
+#     )
+#     resource = Resource.from_descriptor(
+#         {"name": "t", "path": "t.csv", "$schema": V2, "schema": "schema.json"},
+#         basepath=str(tmp_path),
+#     )
+#     assert resource.schema.standard_version == "v2"
+#
+#
+# # `basepath` inheritance (same push mechanism, opposite precedence)
+# #
+# # Unlike `standard_version` (where the parent always wins), a resource's own
+# # basepath takes precedence over the one pushed down by its package.
+#
+#
+# @pytest.mark.parametrize(
+#     "resource_basepath, expected",
+#     (
+#         # No own basepath: inherit the package's
+#         (None, "pkg"),
+#         # Own basepath wins over the package's
+#         ("own", "own"),
+#     ),
+# )
+# def test_resource_inherits_basepath_from_package(resource_basepath, expected):
+#     resource = Resource(path="t.csv", basepath=resource_basepath)
+#     Package(basepath="pkg").add_resource(resource)
+#     assert resource.basepath == expected
+#
+#
+# def test_resource_basepath_reflects_current_package_on_reparent():
+#     resource = Resource(path="t.csv")
+#     Package(basepath="first").add_resource(resource)
+#     assert resource.basepath == "first"
+#     Package(basepath="second").add_resource(resource)
+#     assert resource.basepath == "second"
+>>>>>>> cc5edd81 (🔴 Infer datapackage version from $schema prop)

--- a/frictionless/metadata/__spec__/test_metadata.py
+++ b/frictionless/metadata/__spec__/test_metadata.py
@@ -1,4 +1,6 @@
-from frictionless import Metadata
+import pytest
+
+from frictionless import Metadata, Package, Resource, Schema, settings
 
 # General
 
@@ -11,3 +13,73 @@ def test_metadata():
 def test_metadata_from_path():
     descriptor = Metadata.metadata_retrieve("data/schema-valid.json")
     assert descriptor["primaryKey"] == "id"
+
+
+# @pytest.mark.parametrize(
+#     "Entity, descriptor",
+#     (
+#         (Package, {"resources": []}),
+#         (Schema, {"fields": []}),
+#         (Resource, {"name": "table", "path": "table.csv"}),
+#     ),
+#     ids=["package", "schema", "resource"],
+# )
+# @pytest.mark.parametrize(
+#     "schema, expected",
+#     (
+#         # Absent `$schema`: the spec mandates v1 as the default
+#         (None, "v1"),
+#         # Standard datapackage.org profiles: the version is read from the URL
+#         ("https://datapackage.org/profiles/1.0/datapackage.json", "v1"),
+#         ("https://datapackage.org/profiles/2.0/schema.json", "v2"),
+#         ("https://datapackage.org/profiles/2.1/dataresource.json", "v2"),
+#         # Custom profile: fall back to the default constant
+#         (
+#             "https://example.com/my-profile.json",
+#             settings.DEFAULT_CUSTOM_PROFILE_DATAPACKAGE_VERSION,
+#         ),
+#     ),
+# )
+# def test_datapackage_version_inferred_from_schema(Entity, descriptor, schema, expected):
+#     # Test only for direct inference from the class `$schema` property,
+#     # not inheritance
+#     descriptor = dict(descriptor)
+#     if schema is not None:
+#         descriptor["$schema"] = schema
+#     metadata = Entity.from_descriptor(descriptor)
+#     assert metadata.datapackage_version == expected
+
+
+# `$schema` (de)serialization
+
+SCHEMA_PROFILE = "https://datapackage.org/profiles/2.0/datapackage.json"
+
+
+@pytest.mark.parametrize(
+    "Entity, descriptor",
+    (
+        (Package, {"resources": []}),
+        (Schema, {"fields": []}),
+        (Resource, {"name": "table", "path": "table.csv"}),
+    ),
+    ids=["package", "schema", "resource"],
+)
+def test_schema_profile_imported_from_descriptor(Entity, descriptor):
+    metadata = Entity.from_descriptor({**descriptor, "$schema": SCHEMA_PROFILE})
+    assert metadata._schema_profile == SCHEMA_PROFILE
+    # `$schema` is consumed, not left over in `custom`
+    assert "$schema" not in metadata.custom
+
+
+@pytest.mark.parametrize(
+    "Entity, kwargs",
+    (
+        (Package, {"resources": []}),
+        (Schema, {"fields": []}),
+        (Resource, {"name": "table", "path": "table.csv"}),
+    ),
+    ids=["package", "schema", "resource"],
+)
+def test_schema_profile_exported_to_descriptor(Entity, kwargs):
+    metadata = Entity(schema_profile=SCHEMA_PROFILE, **kwargs)
+    assert metadata.to_descriptor()["$schema"] == SCHEMA_PROFILE

--- a/frictionless/metadata/__spec__/test_metadata.py
+++ b/frictionless/metadata/__spec__/test_metadata.py
@@ -15,7 +15,8 @@ def test_metadata_from_path():
     assert descriptor["primaryKey"] == "id"
 
 
-<<<<<<< HEAD
+# Data package version inference from `$schema` prop
+
 # @pytest.mark.parametrize(
 #     "Entity, descriptor",
 #     (
@@ -56,8 +57,6 @@ def test_metadata_from_path():
 SCHEMA_PROFILE = "https://datapackage.org/profiles/2.0/datapackage.json"
 
 
-=======
->>>>>>> cc5edd81 (🔴 Infer datapackage version from $schema prop)
 @pytest.mark.parametrize(
     "Entity, descriptor",
     (
@@ -67,7 +66,6 @@ SCHEMA_PROFILE = "https://datapackage.org/profiles/2.0/datapackage.json"
     ),
     ids=["package", "schema", "resource"],
 )
-<<<<<<< HEAD
 def test_schema_profile_imported_from_descriptor(Entity, descriptor):
     metadata = Entity.from_descriptor({**descriptor, "$schema": SCHEMA_PROFILE})
     assert metadata._schema_profile == SCHEMA_PROFILE
@@ -87,161 +85,3 @@ def test_schema_profile_imported_from_descriptor(Entity, descriptor):
 def test_schema_profile_exported_to_descriptor(Entity, kwargs):
     metadata = Entity(schema_profile=SCHEMA_PROFILE, **kwargs)
     assert metadata.to_descriptor()["$schema"] == SCHEMA_PROFILE
-=======
-@pytest.mark.parametrize(
-    "schema, expected",
-    (
-        # Absent `$schema`: the spec mandates v1 as the default
-        (None, "v1"),
-        # Standard datapackage.org profiles: the version is read from the URL
-        ("https://datapackage.org/profiles/1.0/datapackage.json", "v1"),
-        ("https://datapackage.org/profiles/2.0/schema.json", "v2"),
-        ("https://datapackage.org/profiles/2.1/dataresource.json", "v2"),
-        # Custom profile: fall back to the default constant
-        (
-            "https://example.com/my-profile.json",
-            settings.DEFAULT_CUSTOM_PROFILE_DATAPACKAGE_VERSION,
-        ),
-    ),
-)
-def test_standard_version_inferred_from_schema(Entity, descriptor, schema, expected):
-    # Test only for direct inference from the class `$schema` property,
-    # not inheritance
-    descriptor = dict(descriptor)
-    if schema is not None:
-        descriptor["$schema"] = schema
-    metadata = Entity.from_descriptor(descriptor)
-    assert metadata.standard_version == expected
-
-
-# Inheritance from a parent entity
-#
-# When an entity is built as part of a parent (a resource inside a package),
-# the parent's resolved version always takes precedence over what the child
-# would infer on its own.
-
-V1 = "https://datapackage.org/profiles/1.0/datapackage.json"
-V2 = "https://datapackage.org/profiles/2.0/datapackage.json"
-
-
-@pytest.mark.parametrize(
-    "package_schema, resource_schema, expected",
-    (
-        # The parent wins, even with a misalignment, in whichever direction it goes
-        (V2, V1, "v2"),
-        (V1, V2, "v1"),
-        # A package without `$schema` resolves to v1 and imposes it
-        (None, V2, "v1"),
-        # The child's own version is used only when consistent with the parent
-        (V2, V2, "v2"),
-        (V2, None, "v2"),
-    ),
-)
-def test_resource_inherits_standard_version_from_package(
-    package_schema, resource_schema, expected
-):
-    resource = {"name": "table", "path": "table.csv"}
-    if resource_schema is not None:
-        resource["$schema"] = resource_schema
-    descriptor = {"resources": [resource]}
-    if package_schema is not None:
-        descriptor["$schema"] = package_schema
-    package = Package.from_descriptor(descriptor)
-    assert package.get_resource("table").standard_version == expected
-
-
-@pytest.mark.parametrize(
-    "resource_schema, schema_schema, expected",
-    (
-        (V2, V1, "v2"),
-        (V1, V2, "v1"),
-        (None, V2, "v1"),
-        (V2, None, "v2"),
-    ),
-)
-def test_schema_inherits_standard_version_from_resource(
-    resource_schema, schema_schema, expected
-):
-    schema = {"fields": [{"name": "a", "type": "string"}]}
-    if schema_schema is not None:
-        schema["$schema"] = schema_schema
-    descriptor = {"name": "table", "path": "table.csv", "schema": schema}
-    if resource_schema is not None:
-        descriptor["$schema"] = resource_schema
-    resource = Resource.from_descriptor(descriptor)
-    assert resource.schema.datapackage_version == expected
-
-
-# # Inheritance through imperative (post-construction) attribution
-# #
-# # The same rule must hold when entities are wired together programmatically,
-# # not only when built from a single descriptor. Inheritance is pushed down at
-# # attach time (no pull, no back-ref); re-parenting re-runs the push, so the
-# # child reflects its current parent. `basepath` rides the same mechanism.
-#
-#
-# def test_resource_inherits_when_added_to_package():
-#     resource = Resource.from_descriptor({"name": "t", "path": "t.csv", "$schema": V1})
-#     assert resource.standard_version == "v1"
-#     package = Package.from_descriptor({"$schema": V2, "resources": []})
-#     package.add_resource(resource)
-#     assert resource.standard_version == "v2"
-#
-#
-# def test_resource_reflects_current_package_on_reparent():
-#     resource = Resource.from_descriptor({"name": "t", "path": "t.csv", "$schema": V2})
-#     Package.from_descriptor({"$schema": V1, "resources": []}).add_resource(resource)
-#     assert resource.standard_version == "v1"
-#     Package.from_descriptor({"$schema": V2, "resources": []}).add_resource(resource)
-#     assert resource.standard_version == "v2"
-#
-#
-# def test_schema_inherits_when_assigned_to_resource():
-#     schema = Schema.from_descriptor(
-#         {"$schema": V1, "fields": [{"name": "a", "type": "string"}]}
-#     )
-#     assert schema.standard_version == "v1"
-#     resource = Resource.from_descriptor({"name": "t", "path": "t.csv", "$schema": V2})
-#     resource.schema = schema
-#     assert resource.schema.standard_version == "v2"
-#
-#
-# def test_schema_from_separate_file_inherits_from_resource(tmp_path):
-#     (tmp_path / "schema.json").write_text(
-#         json.dumps({"$schema": V1, "fields": [{"name": "a", "type": "string"}]})
-#     )
-#     resource = Resource.from_descriptor(
-#         {"name": "t", "path": "t.csv", "$schema": V2, "schema": "schema.json"},
-#         basepath=str(tmp_path),
-#     )
-#     assert resource.schema.standard_version == "v2"
-#
-#
-# # `basepath` inheritance (same push mechanism, opposite precedence)
-# #
-# # Unlike `standard_version` (where the parent always wins), a resource's own
-# # basepath takes precedence over the one pushed down by its package.
-#
-#
-# @pytest.mark.parametrize(
-#     "resource_basepath, expected",
-#     (
-#         # No own basepath: inherit the package's
-#         (None, "pkg"),
-#         # Own basepath wins over the package's
-#         ("own", "own"),
-#     ),
-# )
-# def test_resource_inherits_basepath_from_package(resource_basepath, expected):
-#     resource = Resource(path="t.csv", basepath=resource_basepath)
-#     Package(basepath="pkg").add_resource(resource)
-#     assert resource.basepath == expected
-#
-#
-# def test_resource_basepath_reflects_current_package_on_reparent():
-#     resource = Resource(path="t.csv")
-#     Package(basepath="first").add_resource(resource)
-#     assert resource.basepath == "first"
-#     Package(basepath="second").add_resource(resource)
-#     assert resource.basepath == "second"
->>>>>>> cc5edd81 (🔴 Infer datapackage version from $schema prop)

--- a/frictionless/metadata/metadata.py
+++ b/frictionless/metadata/metadata.py
@@ -576,6 +576,13 @@ class Metadata:
                     yield from Class.metadata_validate(value)  # type: ignore
 
     @classmethod
+    def _accepts_schema_profile(cls) -> bool:
+        """Whether the class declares the `schema_profile` field (i.e. handles
+        `$schema`). The `attrs.has` narrowing is kept local here to avoid
+        polluting the type of `cls` in the callers."""
+        return attrs.has(cls) and "_schema_profile" in attrs.fields_dict(cls)
+
+    @classmethod
     def metadata_import(
         cls,
         descriptor: types.IDescriptor,
@@ -595,10 +602,10 @@ class Metadata:
         # Only the subclasses declaring the `schema_profile` field
         # accept the kwarg; for the others `$schema` is
         # left in the descriptor and round-trips through `custom`.
-        if attrs.has(cls) and "_schema_profile" in attrs.fields_dict(cls):
+        if cls._accepts_schema_profile():
             schema_profile = descriptor.pop("$schema", None)
             if schema_profile is not None:
-                merged_options.setdefault("schema_profile", schema_profile)
+                merged_options.setdefault("schema_profile", schema_profile)  # type: ignore
         is_typed_class = isinstance(getattr(cls, "type", None), str)
         for name in profile.get("properties", {}):
             value = descriptor.pop(name, None)

--- a/frictionless/metadata/metadata.py
+++ b/frictionless/metadata/metadata.py
@@ -21,6 +21,7 @@ from typing import (
     Union,
 )
 
+import attrs
 from typing_extensions import Self
 
 from .. import helpers
@@ -589,6 +590,15 @@ class Metadata:
         merged_options = {}
         profile = cls.metadata_ensure_profile()
         basepath = options.pop("basepath", None)
+
+        # Special handling of `$schema`
+        # Only the subclasses declaring the `schema_profile` field
+        # accept the kwarg; for the others `$schema` is
+        # left in the descriptor and round-trips through `custom`.
+        if attrs.has(cls) and "_schema_profile" in attrs.fields_dict(cls):
+            schema_profile = descriptor.pop("$schema", None)
+            if schema_profile is not None:
+                merged_options.setdefault("schema_profile", schema_profile)
         is_typed_class = isinstance(getattr(cls, "type", None), str)
         for name in profile.get("properties", {}):
             value = descriptor.pop(name, None)

--- a/frictionless/metadata/metadata.py
+++ b/frictionless/metadata/metadata.py
@@ -642,5 +642,10 @@ class Metadata:
             if isinstance(value, (list, dict)):
                 value = deepcopy(value)  # type: ignore
             descriptor[name] = value
+
+        # Special handling of `$schema`
+        if self._schema_profile is not None:
+            descriptor["$schema"] = self._schema_profile
+
         descriptor.update(self.custom)  # type: ignore
         return descriptor  # type: ignore

--- a/frictionless/metadata/metadata.py
+++ b/frictionless/metadata/metadata.py
@@ -66,6 +66,13 @@ class Metadata:
     classe's "profile" (See the "metadata_profile_*" properties)
     """
 
+    _schema_profile: Optional[str] = None
+    """
+    `$schema` property value, a JSON-schema profile URL this metadata follows.
+    It is (de)serialized specially in `metadata_import`/`metadata_export` because
+    `$schema` is not a valid Python identifier.
+    """
+
     def __new__(cls, *args: Any, **kwargs: Any):
         obj = super().__new__(cls)
         obj.custom = obj.custom.copy()

--- a/frictionless/package/package.py
+++ b/frictionless/package/package.py
@@ -58,6 +58,12 @@ class Package(Metadata, metaclass=Factory):
     # TODO: add docs
     """
 
+    _schema_profile: Optional[str] = attrs.field(default=None, alias="schema_profile")
+    """
+    `$schema` property value, a JSON-schema profile URL this metadata follows.
+    See `Metadata._schema_profile`.
+    """
+
     name: Optional[str] = None
     """
     A short url-usable (and preferably human-readable) name.

--- a/frictionless/resource/resource.py
+++ b/frictionless/resource/resource.py
@@ -203,6 +203,12 @@ class Resource(Metadata, metaclass=Factory):  # type: ignore
     # TODO: add docs
     """
 
+    _schema_profile: Optional[str] = attrs.field(default=None, alias="schema_profile")
+    """
+    `$schema` property value, a JSON-schema profile URL this metadata follows.
+    See `Metadata._schema_profile`.
+    """
+
     detector: Detector = attrs.field(factory=Detector)
     """
     File/table detector.

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -34,6 +34,12 @@ class Schema(Metadata, metaclass=Factory):
     # TODO: add docs
     """
 
+    _schema_profile: Optional[str] = attrs.field(default=None, alias="schema_profile")
+    """
+    `$schema` property value, a JSON-schema profile URL this metadata follows.
+    See `Metadata._schema_profile`.
+    """
+
     # TODO: why it's optional??
     name: Optional[str] = None
     """


### PR DESCRIPTION
Adds `$schema` reading from descriptor and writing to_descriptor for datapackage v2 : 
- package.$schema
- resource.$schema
- schema.$schema
- dialect.$schema

> A root level [xxx] descriptor MAY have a $schema property

No validation is performed against the $schema properties yet.

### implementation details

Implemented on Metadata (`_schema_profile` property, to not clash with e.g. `resource.schema` and as `$schema` is not a valid python symbol), but only child classes with explicit declaration will read it (for others, it will be considered a `custom` property). 