### PR TITLE
feat: missing values as objects (DPv2)

### DIFF
--- a/frictionless/inquiry/task.py
+++ b/frictionless/inquiry/task.py
@@ -214,8 +214,15 @@ class InquiryTask(Metadata):
             warnings.warn(note, UserWarning)
 
     @classmethod
-    def metadata_validate(cls, descriptor: types.IDescriptor):  # type: ignore
-        metadata_errors = list(super().metadata_validate(descriptor))
+    def metadata_validate(  # type: ignore
+        cls,
+        descriptor: types.IDescriptor,
+        *,
+        datapackage_version: Optional[types.IStandards] = None,
+    ):
+        metadata_errors = list(
+            super().metadata_validate(descriptor, datapackage_version=datapackage_version)
+        )
         if metadata_errors:
             yield from metadata_errors
             return

--- a/frictionless/metadata/metadata.py
+++ b/frictionless/metadata/metadata.py
@@ -556,7 +556,7 @@ class Metadata:
         "datapackage_version" is the Data Package standard version imposed by an
         ancestor's `$schema` (top-down inheritance). When `None`, the descriptor
         may declare its own `$schema`; the resulting version is propagated to all
-        children. Subclasses read it (via `metadata_effective_datapackage_version`)
+        children. Subclasses read it (via `effective_datapackage_version`)
         to gate version-specific properties.
         """
         Error = error_class

--- a/frictionless/metadata/metadata.py
+++ b/frictionless/metadata/metadata.py
@@ -543,6 +543,7 @@ class Metadata:
         *,
         profile: Optional[Union[types.IDescriptor, str]] = None,
         error_class: Optional[Type[Error]] = None,
+        datapackage_version: Optional[types.IStandards] = None,
     ) -> Generator[Error, None, None]:
         """Validates a descriptor according to a profile
 
@@ -551,6 +552,12 @@ class Metadata:
 
         The profile to validate can be set explicitely ("profile" parameter),
         otherwise it defaults to the class profile.
+
+        "datapackage_version" is the Data Package standard version imposed by an
+        ancestor's `$schema` (top-down inheritance). When `None`, the descriptor
+        may declare its own `$schema`; the resulting version is propagated to all
+        children. Subclasses read it (via `metadata_effective_datapackage_version`)
+        to gate version-specific properties.
         """
         Error = error_class
         if not Error:
@@ -570,6 +577,7 @@ class Metadata:
                 note = f"{note} at property '{metadata_path}'"
             yield Error(note=note)
 
+        version = cls.effective_datapackage_version(descriptor, datapackage_version)
         for name in profile.get("properties", {}):
             value = descriptor.get(name)
             Class = cls.metadata_select_property_class(name)
@@ -579,9 +587,15 @@ class Metadata:
                         if isinstance(item, dict):
                             type = item.get("type")  # type: ignore
                             ItemClass = Class.metadata_select_class(type)  # type: ignore
-                            yield from ItemClass.metadata_validate(item)  # type: ignore
+                            yield from ItemClass.metadata_validate(
+                                item,  # type: ignore
+                                datapackage_version=version,
+                            )
                 elif isinstance(value, dict):
-                    yield from Class.metadata_validate(value)  # type: ignore
+                    yield from Class.metadata_validate(
+                        value,  # type: ignore
+                        datapackage_version=version,
+                    )
 
     @classmethod
     def _accepts_schema_profile(cls) -> bool:
@@ -611,6 +625,26 @@ class Metadata:
                 if match.group(1) == "2":
                     return "v2"
         return settings.DEFAULT_STANDARDS
+
+    @classmethod
+    def effective_datapackage_version(
+        cls,
+        descriptor: types.IDescriptor,
+        inherited: Optional[types.IStandards],
+    ) -> Optional[types.IStandards]:
+        """Version imposed top-down on this descriptor and its descendants.
+
+        An ancestor's `$schema` wins (a descendant cannot escape it); otherwise
+        the descriptor's own `$schema`, if any, sets the version. Returns `None`
+        when no `$schema` is declared anywhere in the chain (undeclared version,
+        which validation treats leniently).
+        """
+        if inherited is not None:
+            return inherited
+        schema_profile = descriptor.get("$schema")
+        if schema_profile:
+            return cls._resolve_datapackage_version(schema_profile)
+        return None
 
     @classmethod
     def metadata_import(

--- a/frictionless/metadata/metadata.py
+++ b/frictionless/metadata/metadata.py
@@ -20,17 +20,17 @@ from typing import (
     Type,
     Union,
 )
+from urllib.parse import urlparse
 
 import attrs
 from typing_extensions import Self
 
-from .. import helpers
+from .. import helpers, settings, types
 from ..exception import FrictionlessException
 from ..platform import platform
 from ..vendors import stringcase
 
 if TYPE_CHECKING:
-    from .. import types
     from ..error import Error
     from ..report import Report
 
@@ -589,6 +589,28 @@ class Metadata:
         `$schema`). The `attrs.has` narrowing is kept local here to avoid
         polluting the type of `cls` in the callers."""
         return attrs.has(cls) and "_schema_profile" in attrs.fields_dict(cls)
+
+    @staticmethod
+    def _resolve_datapackage_version(
+        schema_profile: Optional[str],
+    ) -> types.IStandards:
+        """Resolve the Data Package standard version from a `$schema` value.
+
+        - a missing `$schema` defaults to "v1" (as mandated by the spec);
+        - a standard datapackage.org profile uses the version from its URL;
+        - any custom profile falls back to the latest known standard.
+        """
+        if not schema_profile:
+            return "v1"
+        url = urlparse(schema_profile)
+        if url.netloc == "datapackage.org":
+            match = re.search(r"/profiles/(\d+)\.\d+/", url.path)
+            if match:
+                if match.group(1) == "1":
+                    return "v1"
+                if match.group(1) == "2":
+                    return "v2"
+        return settings.DEFAULT_STANDARDS
 
     @classmethod
     def metadata_import(

--- a/frictionless/metadata/metadata.py
+++ b/frictionless/metadata/metadata.py
@@ -278,8 +278,16 @@ class Metadata:
         return metadata  # type: ignore
 
     def to_descriptor(self, *, validate: bool = False) -> types.IDescriptor:
-        """Return a descriptor associated to the class instance.
-        If `validate = True`, the descriptor will additionnaly be validated.
+        """Export the instance as a descriptor.
+
+        The descriptor is a canonical form of the metadata: it preserves all
+        the information the instance holds, but is not guaranteed to be
+        syntactically identical to the descriptor the instance was created
+        from (equivalent notations are normalized). Exporting is idempotent:
+        re-importing the result and exporting it again returns the same
+        descriptor.
+
+        If `validate = True`, the descriptor will additionally be validated.
         """
         descriptor = self.metadata_export()
         if validate:

--- a/frictionless/package/__spec__/test_validate.py
+++ b/frictionless/package/__spec__/test_validate.py
@@ -677,3 +677,85 @@ def test_package_validate_with_parallel():
         [1, 3, None, "primary-key"],
         [2, 4, None, "blank-row"],
     ]
+
+
+# Missing values version gate — inheritance through the package
+#
+# A package `$schema` imposes its version on its resources/schemas/fields
+# (top-down). The object form of `missingValues` is a datapackage v2 addition,
+# rejected when the imposed version is v1. A descendant cannot escape it by
+# declaring a v2 `$schema` of its own.
+
+DP_V1_PROFILE = "https://datapackage.org/profiles/1.0/datapackage.json"
+DP_V2_PROFILE = "https://datapackage.org/profiles/2.0/datapackage.json"
+TS_V2_PROFILE = "https://datapackage.org/profiles/2.0/tableschema.json"
+GATE_NOTE = "missing values in object form require datapackage v2"
+OBJECT_MISSING_VALUES = [{"value": "-99", "label": "REFUSED"}]
+
+
+def _package_with_object_missing_values(package_profile, schema_own_profile, location):
+    schema = {"fields": [{"name": "name", "type": "string"}]}
+    if schema_own_profile is not None:
+        schema["$schema"] = schema_own_profile
+    if location == "schema":
+        schema["missingValues"] = OBJECT_MISSING_VALUES
+    else:
+        schema["fields"][0]["missingValues"] = OBJECT_MISSING_VALUES
+    descriptor = {
+        "resources": [{"name": "table", "path": "data/table.csv", "schema": schema}]
+    }
+    if package_profile is not None:
+        descriptor["$schema"] = package_profile
+    return descriptor
+
+
+MISSING_VALUES_INHERITANCE_CASES = [
+    # schema inherits the package version
+    (
+        "schema-inherits-package-v1",
+        DP_V1_PROFILE,
+        None,
+        "schema",
+        [["schema-error", GATE_NOTE]],
+    ),
+    ("schema-inherits-package-v2", DP_V2_PROFILE, None, "schema", []),
+    # field inherits the package version (through a schema without its own $schema)
+    (
+        "field-inherits-package-v1",
+        DP_V1_PROFILE,
+        None,
+        "field",
+        [["field-error", GATE_NOTE]],
+    ),
+    ("field-inherits-package-v2", DP_V2_PROFILE, None, "field", []),
+    # a descendant cannot escape the imposed v1 by declaring its own v2 $schema
+    (
+        "schema-cannot-escape-package-v1",
+        DP_V1_PROFILE,
+        TS_V2_PROFILE,
+        "schema",
+        [["schema-error", GATE_NOTE]],
+    ),
+    (
+        "field-cannot-escape-package-v1",
+        DP_V1_PROFILE,
+        TS_V2_PROFILE,
+        "field",
+        [["field-error", GATE_NOTE]],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name, package_profile, schema_own_profile, location, expected",
+    MISSING_VALUES_INHERITANCE_CASES,
+    ids=[case[0] for case in MISSING_VALUES_INHERITANCE_CASES],
+)
+def test_package_validate_missing_values_version_gate_inheritance(
+    name, package_profile, schema_own_profile, location, expected
+):
+    descriptor = _package_with_object_missing_values(
+        package_profile, schema_own_profile, location
+    )
+    report = Package.validate_descriptor(descriptor)
+    assert report.flatten(["type", "note"]) == expected

--- a/frictionless/package/package.py
+++ b/frictionless/package/package.py
@@ -659,8 +659,15 @@ class Package(Metadata, metaclass=Factory):
                 descriptor["profile"] = profiles[0]
 
     @classmethod
-    def metadata_validate(cls, descriptor: types.IDescriptor):  # type: ignore
-        metadata_errors = list(super().metadata_validate(descriptor))
+    def metadata_validate(  # type: ignore
+        cls,
+        descriptor: types.IDescriptor,
+        *,
+        datapackage_version: Optional[types.IStandards] = None,
+    ):
+        metadata_errors = list(
+            super().metadata_validate(descriptor, datapackage_version=datapackage_version)
+        )
         if metadata_errors:
             yield from metadata_errors
             return
@@ -721,6 +728,7 @@ class Package(Metadata, metaclass=Factory):
                 descriptor,
                 profile=profile,
                 error_class=cls.metadata_Error,
+                datapackage_version=datapackage_version,
             )
 
         # Profile (tabular)

--- a/frictionless/resource/resource.py
+++ b/frictionless/resource/resource.py
@@ -896,8 +896,15 @@ class Resource(Metadata, metaclass=Factory):  # type: ignore
             warnings.warn(note, UserWarning)
 
     @classmethod
-    def metadata_validate(cls, descriptor: types.IDescriptor):  # type: ignore
-        metadata_errors = list(super().metadata_validate(descriptor))
+    def metadata_validate(  # type: ignore
+        cls,
+        descriptor: types.IDescriptor,
+        *,
+        datapackage_version: Optional[types.IStandards] = None,
+    ):
+        metadata_errors = list(
+            super().metadata_validate(descriptor, datapackage_version=datapackage_version)
+        )
         if metadata_errors:
             yield from metadata_errors
             return
@@ -948,6 +955,7 @@ class Resource(Metadata, metaclass=Factory):  # type: ignore
                 descriptor,
                 profile=profile,
                 error_class=cls.metadata_Error,
+                datapackage_version=datapackage_version,
             )
 
         # Profile (tabular)

--- a/frictionless/schema/__spec__/field/test_convert.py
+++ b/frictionless/schema/__spec__/field/test_convert.py
@@ -1,3 +1,5 @@
+import pytest
+
 from frictionless import Field, Schema
 
 # General
@@ -8,6 +10,39 @@ def test_field_to_copy():
     target = source.to_copy()
     assert source is not target
     assert source == target
+
+
+# Missing values
+#
+# `to_descriptor` returns a canonical form: the information (values, labels)
+# is preserved, the notation is not. Object entries are emitted only when at
+# least one label exists; otherwise the entries canonicalize to plain strings.
+
+MISSING_VALUES_EXPORT_CASES = [
+    ("strings", ["", "NA"], ["", "NA"]),
+    (
+        "objects-with-labels",
+        [{"value": "-99", "label": "REFUSED"}, {"value": ""}],
+        [{"value": "-99", "label": "REFUSED"}, {"value": ""}],
+    ),
+    ("objects-without-labels", [{"value": "-"}], ["-"]),
+]
+
+
+@pytest.mark.parametrize(
+    "name, source, expected",
+    MISSING_VALUES_EXPORT_CASES,
+    ids=[case[0] for case in MISSING_VALUES_EXPORT_CASES],
+)
+def test_field_to_descriptor_missing_values_canonical_form(name, source, expected):
+    descriptor = {"name": "name", "type": "string", "missingValues": source}
+    exported = Field.from_descriptor(descriptor).to_descriptor()["missingValues"]
+    assert exported == expected
+    # the canonical form is a fixed point: re-importing it exports identically
+    reimported = Field.from_descriptor(
+        {"name": "name", "type": "string", "missingValues": exported}
+    )
+    assert reimported.to_descriptor()["missingValues"] == exported
 
 
 def test_field_set_schema():

--- a/frictionless/schema/__spec__/field/test_read.py
+++ b/frictionless/schema/__spec__/field/test_read.py
@@ -31,6 +31,22 @@ def test_field_read_cell_string_missing_values():
     assert field.read_cell("N/A") == (None, None)
 
 
+def test_field_read_cell_object_missing_values():
+    field = Field.from_descriptor(
+        {
+            "name": "name",
+            "type": "string",
+            "missingValues": [
+                {"value": "", "label": "OMITTED"},
+                {"value": "-99", "label": "REFUSED"},
+            ],
+        }
+    )
+    assert field.read_cell("") == (None, None)
+    assert field.read_cell("-99") == (None, None)
+    assert field.read_cell("x") == ("x", None)
+
+
 def test_field_read_cell_number_missingValues():
     field = Field.from_descriptor(
         {

--- a/frictionless/schema/__spec__/test_convert.py
+++ b/frictionless/schema/__spec__/test_convert.py
@@ -55,6 +55,42 @@ def test_schema_to_copy():
     assert source.to_descriptor() == target.to_descriptor()
 
 
+# Missing values
+#
+# `to_descriptor` returns a canonical form: the information (values, labels)
+# is preserved, the notation is not. Object entries are emitted only when at
+# least one label exists; otherwise the entries canonicalize to plain strings.
+
+MISSING_VALUES_EXPORT_CASES = [
+    ("strings", ["", "NA"], ["", "NA"]),
+    (
+        "objects-with-labels",
+        [{"value": "-99", "label": "REFUSED"}, {"value": ""}],
+        [{"value": "-99", "label": "REFUSED"}, {"value": ""}],
+    ),
+    ("objects-without-labels", [{"value": "-"}], ["-"]),
+]
+
+
+@pytest.mark.parametrize(
+    "name, source, expected",
+    MISSING_VALUES_EXPORT_CASES,
+    ids=[case[0] for case in MISSING_VALUES_EXPORT_CASES],
+)
+def test_schema_to_descriptor_missing_values_canonical_form(name, source, expected):
+    descriptor = {
+        "fields": [{"name": "name", "type": "string"}],
+        "missingValues": source,
+    }
+    exported = Schema.from_descriptor(descriptor).to_descriptor()["missingValues"]
+    assert exported == expected
+    # the canonical form is a fixed point: re-importing it exports identically
+    reimported = Schema.from_descriptor(
+        {"fields": [{"name": "name", "type": "string"}], "missingValues": exported}
+    )
+    assert reimported.to_descriptor()["missingValues"] == exported
+
+
 def test_schema_to_json(tmpdir):
     output_file_path = str(tmpdir.join("schema.json"))
     schema = Schema.from_descriptor(DESCRIPTOR_MIN)

--- a/frictionless/schema/__spec__/test_general.py
+++ b/frictionless/schema/__spec__/test_general.py
@@ -87,6 +87,27 @@ def test_schema_read_cells_null_values():
     assert len(notes) == 5
 
 
+def test_schema_read_cells_object_missing_values():
+    schema = Schema.from_descriptor(
+        {
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "age", "type": "integer"},
+            ],
+            "missingValues": [
+                {"value": "", "label": "OMITTED"},
+                {"value": "-99", "label": "REFUSED"},
+            ],
+        }
+    )
+    assert schema.missing_values == ["", "-99"]
+    source = ["-99", ""]
+    target = [None, None]
+    cells, notes = schema.read_cells(source)
+    assert cells == target
+    assert len(notes) == 2
+
+
 def test_schema_read_cells_too_short():
     schema = Schema(DESCRIPTOR_MAX)
     source = ["string", "10.0", "1", "string"]

--- a/frictionless/schema/__spec__/test_validate.py
+++ b/frictionless/schema/__spec__/test_validate.py
@@ -110,13 +110,14 @@ V2_PROFILE = "https://datapackage.org/profiles/2.0/tableschema.json"
 CUSTOM_PROFILE = "https://example.com/profiles/custom-tableschema.json"
 
 OBJECT_MISSING_VALUES = [{"value": "-99", "label": "REFUSED"}]
+GATE_NOTE = "missing values in object form require datapackage v2"
 
 MISSING_VALUES_VERSION_GATE_CASES = [
     (
         "v1-objects-rejected",
         V1_PROFILE,
         OBJECT_MISSING_VALUES,
-        [["schema-error", "missing values in object form require datapackage v2"]],
+        [["schema-error", GATE_NOTE]],
     ),
     ("v1-strings-valid", V1_PROFILE, ["", "NA"], []),
     ("v2-objects-valid", V2_PROFILE, OBJECT_MISSING_VALUES, []),
@@ -134,6 +135,37 @@ def test_validate_missing_values_version_gate(name, schema, source, expected):
     descriptor = {
         "fields": [{"name": "name", "type": "string"}],
         "missingValues": source,
+    }
+    if schema is not None:
+        descriptor["$schema"] = schema
+    report = Schema.validate_descriptor(descriptor)
+    assert report.flatten(["type", "note"]) == expected
+
+
+# Missing values version gate — inheritance
+#
+# A `$schema` imposes its version on all descendants (top-down): a schema's
+# version applies to its fields, and a field never declares its own `$schema`.
+
+MISSING_VALUES_FIELD_INHERITS_SCHEMA_CASES = [
+    ("v1-schema-rejects-field-objects", V1_PROFILE, [["field-error", GATE_NOTE]]),
+    ("v2-schema-accepts-field-objects", V2_PROFILE, []),
+    ("no-schema-accepts-field-objects", None, []),
+]
+
+
+@pytest.mark.parametrize(
+    "name, schema, expected",
+    MISSING_VALUES_FIELD_INHERITS_SCHEMA_CASES,
+    ids=[case[0] for case in MISSING_VALUES_FIELD_INHERITS_SCHEMA_CASES],
+)
+def test_validate_missing_values_version_gate_field_inherits_schema(
+    name, schema, expected
+):
+    descriptor = {
+        "fields": [
+            {"name": "name", "type": "string", "missingValues": OBJECT_MISSING_VALUES}
+        ]
     }
     if schema is not None:
         descriptor["$schema"] = schema

--- a/frictionless/schema/__spec__/test_validate.py
+++ b/frictionless/schema/__spec__/test_validate.py
@@ -98,6 +98,49 @@ def test_validate_field_missing_values_uniqueness():
     ]
 
 
+# Missing values (version gate)
+#
+# The object form `{value, label?}` is a datapackage v2 addition.
+# It is rejected only under an explicitly declared v1 `$schema`.
+# An absent `$schema` (undeclared version) keeps accepting the v1 union v2
+# superset, and a custom (unrecognized) profile is treated as v2 by default.
+
+V1_PROFILE = "https://datapackage.org/profiles/1.0/tableschema.json"
+V2_PROFILE = "https://datapackage.org/profiles/2.0/tableschema.json"
+CUSTOM_PROFILE = "https://example.com/profiles/custom-tableschema.json"
+
+OBJECT_MISSING_VALUES = [{"value": "-99", "label": "REFUSED"}]
+
+MISSING_VALUES_VERSION_GATE_CASES = [
+    (
+        "v1-objects-rejected",
+        V1_PROFILE,
+        OBJECT_MISSING_VALUES,
+        [["schema-error", "missing values in object form require datapackage v2"]],
+    ),
+    ("v1-strings-valid", V1_PROFILE, ["", "NA"], []),
+    ("v2-objects-valid", V2_PROFILE, OBJECT_MISSING_VALUES, []),
+    ("custom-objects-valid", CUSTOM_PROFILE, OBJECT_MISSING_VALUES, []),
+    ("no-schema-objects-valid", None, OBJECT_MISSING_VALUES, []),
+]
+
+
+@pytest.mark.parametrize(
+    "name, schema, source, expected",
+    MISSING_VALUES_VERSION_GATE_CASES,
+    ids=[case[0] for case in MISSING_VALUES_VERSION_GATE_CASES],
+)
+def test_validate_missing_values_version_gate(name, schema, source, expected):
+    descriptor = {
+        "fields": [{"name": "name", "type": "string"}],
+        "missingValues": source,
+    }
+    if schema is not None:
+        descriptor["$schema"] = schema
+    report = Schema.validate_descriptor(descriptor)
+    assert report.flatten(["type", "note"]) == expected
+
+
 def test_validate_inline_set_default_field_type_if_missing():
     report = Schema.validate_descriptor(
         {"fields": [{"name": "name"}, {"name": "id", "type": "integer"}]}

--- a/frictionless/schema/__spec__/test_validate.py
+++ b/frictionless/schema/__spec__/test_validate.py
@@ -1,3 +1,5 @@
+import pytest
+
 from frictionless import Schema
 
 # General
@@ -25,6 +27,74 @@ def test_validate_required_invalid():
             "field-error",
             '"required" should be set as "constraints.required"',
         ],
+    ]
+
+
+# Missing values (uniqueness of value and label)
+#
+# Object entries must have a unique value and an optional unique label;
+# absent labels do not collide with each other. Plain string entries keep
+# the lax v1 behavior (duplicates allowed).
+
+MISSING_VALUES_UNIQUENESS_CASES = [
+    ("valid-strings", ["", "NA"], []),
+    ("valid-duplicate-strings", ["NA", "NA"], []),
+    (
+        "valid-objects",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "", "label": "OMITTED"}],
+        [],
+    ),
+    ("missing-labels-do-not-collide", [{"value": "-99"}, {"value": "-1"}], []),
+    (
+        "duplicate-value",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "-99", "label": "OMITTED"}],
+        [["schema-error", 'missing value "-99" is not unique']],
+    ),
+    (
+        "duplicate-label",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "", "label": "REFUSED"}],
+        [["schema-error", 'missing value label "REFUSED" is not unique']],
+    ),
+    (
+        "duplicate-value-and-label",
+        [{"value": "-99", "label": "REFUSED"}, {"value": "-99", "label": "REFUSED"}],
+        [
+            ["schema-error", 'missing value "-99" is not unique'],
+            ["schema-error", 'missing value label "REFUSED" is not unique'],
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name, source, expected",
+    MISSING_VALUES_UNIQUENESS_CASES,
+    ids=[case[0] for case in MISSING_VALUES_UNIQUENESS_CASES],
+)
+def test_validate_missing_values_uniqueness(name, source, expected):
+    report = Schema.validate_descriptor(
+        {"fields": [{"name": "name", "type": "string"}], "missingValues": source}
+    )
+    assert report.flatten(["type", "note"]) == expected
+
+
+def test_validate_field_missing_values_uniqueness():
+    report = Schema.validate_descriptor(
+        {
+            "fields": [
+                {
+                    "name": "name",
+                    "type": "string",
+                    "missingValues": [
+                        {"value": "-99", "label": "REFUSED"},
+                        {"value": "-99", "label": "OMITTED"},
+                    ],
+                }
+            ]
+        }
+    )
+    assert report.flatten(["type", "note"]) == [
+        ["field-error", 'missing value "-99" is not unique']
     ]
 
 

--- a/frictionless/schema/field.py
+++ b/frictionless/schema/field.py
@@ -93,6 +93,11 @@ class Field(Metadata):
             note = 'Use "schema.set_field_type()" to update the type of the field'
             raise FrictionlessException(errors.FieldError(note=note))
         if name == "missing_values" and isinstance(value, list):
+            self._missing_values_labels = {
+                item["value"]: item["label"]
+                for item in value
+                if isinstance(item, dict) and item.get("label") is not None
+            }
             value = [
                 item["value"] if isinstance(item, dict) else item for item in value
             ]
@@ -305,6 +310,24 @@ class Field(Metadata):
             if name in descriptor:
                 note = f'"{name}" should be set as "constraints.{name}"'
                 yield errors.FieldError(note=note)
+
+    def metadata_export(self, *, exclude: List[str] = []) -> IDescriptor:
+        descriptor = super().metadata_export(exclude=exclude)
+
+        # Canonical form: object entries if and only if at least one label exists
+        missing_values = descriptor.get("missingValues")
+        labels = getattr(self, "_missing_values_labels", {})
+        if isinstance(missing_values, list) and any(
+            value in labels for value in missing_values
+        ):
+            descriptor["missingValues"] = [
+                {"value": value, "label": labels[value]}
+                if value in labels
+                else {"value": value}
+                for value in missing_values
+            ]
+
+        return descriptor
 
 
 # Internal

--- a/frictionless/schema/field.py
+++ b/frictionless/schema/field.py
@@ -269,6 +269,12 @@ class Field(Metadata):
                 note = f'constraint "{name}" is not supported by type "{cls.type}"'
                 yield errors.FieldError(note=note)
 
+        # Missing Values
+        for note in missing_values_module.validation_notes(
+            descriptor.get("missingValues", [])
+        ):
+            yield errors.FieldError(note=note)
+
         # Examples
         example = descriptor.get("example")
         if example:

--- a/frictionless/schema/field.py
+++ b/frictionless/schema/field.py
@@ -282,9 +282,7 @@ class Field(Metadata):
         # Missing Values version gate
         # A field never declares its own `$schema`; the version is the one
         # imposed top-down by an ancestor (`None` undeclared stays lenient).
-        version = cls.metadata_effective_datapackage_version(
-            descriptor, datapackage_version
-        )
+        version = cls.effective_datapackage_version(descriptor, datapackage_version)
         for note in missing_values_module.version_gate_notes(missing_values, version):
             yield errors.FieldError(note=note)
 

--- a/frictionless/schema/field.py
+++ b/frictionless/schema/field.py
@@ -24,7 +24,7 @@ from ..system import system
 from . import missing_values as missing_values_module
 
 if TYPE_CHECKING:
-    from ..types import IDescriptor
+    from ..types import IDescriptor, IStandards
     from . import types
     from .schema import Schema
 
@@ -61,9 +61,7 @@ class Field(Metadata):
     For example: "default","array" etc.
     """
 
-    missing_values: List[str] = attrs.field(
-        factory=settings.DEFAULT_MISSING_VALUES.copy
-    )
+    missing_values: List[str] = attrs.field(factory=settings.DEFAULT_MISSING_VALUES.copy)
     """
     List of string values to be set as missing values in the field. If any of string in missing values
     is found in the field value then it is set as None.
@@ -257,8 +255,15 @@ class Field(Metadata):
             descriptor["format"] = format.replace("fmt:", "")
 
     @classmethod
-    def metadata_validate(cls, descriptor: IDescriptor):  # type: ignore
-        metadata_errors = list(super().metadata_validate(descriptor))
+    def metadata_validate(  # type: ignore
+        cls,
+        descriptor: IDescriptor,
+        *,
+        datapackage_version: Optional[IStandards] = None,
+    ):
+        metadata_errors = list(
+            super().metadata_validate(descriptor, datapackage_version=datapackage_version)
+        )
         if metadata_errors:
             yield from metadata_errors
             return
@@ -270,9 +275,17 @@ class Field(Metadata):
                 yield errors.FieldError(note=note)
 
         # Missing Values
-        for note in missing_values_module.validation_notes(
-            descriptor.get("missingValues", [])
-        ):
+        missing_values = descriptor.get("missingValues", [])
+        for note in missing_values_module.validation_notes(missing_values):
+            yield errors.FieldError(note=note)
+
+        # Missing Values version gate
+        # A field never declares its own `$schema`; the version is the one
+        # imposed top-down by an ancestor (`None` undeclared stays lenient).
+        version = cls.metadata_effective_datapackage_version(
+            descriptor, datapackage_version
+        )
+        for note in missing_values_module.version_gate_notes(missing_values, version):
             yield errors.FieldError(note=note)
 
         # Examples
@@ -294,9 +307,7 @@ class Field(Metadata):
                     field.false_values = descriptor["falseValues"]
             _, notes = field.read_cell(example)
             if notes is not None:
-                note = (
-                    f'example value "{example}" for field "{field.name}" is not valid'
-                )
+                note = f'example value "{example}" for field "{field.name}" is not valid'
                 yield errors.FieldError(note=note)
 
         # Misleading

--- a/frictionless/schema/field.py
+++ b/frictionless/schema/field.py
@@ -92,6 +92,10 @@ class Field(Metadata):
         if name == "type":
             note = 'Use "schema.set_field_type()" to update the type of the field'
             raise FrictionlessException(errors.FieldError(note=note))
+        if name == "missing_values" and isinstance(value, list):
+            value = [
+                item["value"] if isinstance(item, dict) else item for item in value
+            ]
         return super().__setattr__(name, value)  # type: ignore
 
     @property
@@ -210,8 +214,23 @@ class Field(Metadata):
             "description": {"type": "string"},
             "format": {"type": "string"},
             "missingValues": {
-                "type": "array",
-                "items": {"type": "string"},
+                "anyOf": [
+                    {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["value"],
+                            "properties": {
+                                "value": {"type": "string"},
+                                "label": {"type": "string"},
+                            },
+                        },
+                    },
+                ],
             },
             "constraints": {
                 "type": "object",

--- a/frictionless/schema/field.py
+++ b/frictionless/schema/field.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import decimal
 import re
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Pattern
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Pattern,
+    cast,
+)
 
 import attrs
 
@@ -11,6 +21,7 @@ from .. import errors, settings
 from ..exception import FrictionlessException
 from ..metadata import Metadata
 from ..system import system
+from . import missing_values as missing_values_module
 
 if TYPE_CHECKING:
     from ..types import IDescriptor
@@ -93,14 +104,9 @@ class Field(Metadata):
             note = 'Use "schema.set_field_type()" to update the type of the field'
             raise FrictionlessException(errors.FieldError(note=note))
         if name == "missing_values" and isinstance(value, list):
-            self._missing_values_labels = {
-                item["value"]: item["label"]
-                for item in value
-                if isinstance(item, dict) and item.get("label") is not None
-            }
-            value = [
-                item["value"] if isinstance(item, dict) else item for item in value
-            ]
+            value, self._missing_values_labels = missing_values_module.split(
+                cast(missing_values_module.IEntries, value)
+            )
         return super().__setattr__(name, value)  # type: ignore
 
     @property
@@ -218,25 +224,7 @@ class Field(Metadata):
             "title": {"type": "string"},
             "description": {"type": "string"},
             "format": {"type": "string"},
-            "missingValues": {
-                "anyOf": [
-                    {
-                        "type": "array",
-                        "items": {"type": "string"},
-                    },
-                    {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["value"],
-                            "properties": {
-                                "value": {"type": "string"},
-                                "label": {"type": "string"},
-                            },
-                        },
-                    },
-                ],
-            },
+            "missingValues": missing_values_module.PROFILE,
             "constraints": {
                 "type": "object",
                 "properties": {
@@ -314,18 +302,12 @@ class Field(Metadata):
     def metadata_export(self, *, exclude: List[str] = []) -> IDescriptor:
         descriptor = super().metadata_export(exclude=exclude)
 
-        # Canonical form: object entries if and only if at least one label exists
         missing_values = descriptor.get("missingValues")
-        labels = getattr(self, "_missing_values_labels", {})
-        if isinstance(missing_values, list) and any(
-            value in labels for value in missing_values
-        ):
-            descriptor["missingValues"] = [
-                {"value": value, "label": labels[value]}
-                if value in labels
-                else {"value": value}
-                for value in missing_values
-            ]
+        if isinstance(missing_values, list):
+            descriptor["missingValues"] = missing_values_module.export(
+                cast(List[str], missing_values),
+                getattr(self, "_missing_values_labels", {}),
+            )
 
         return descriptor
 

--- a/frictionless/schema/missing_values.py
+++ b/frictionless/schema/missing_values.py
@@ -1,0 +1,61 @@
+"""Helpers for the `missingValues` property, shared by Schema and Field.
+
+Datapackage v2 allows object entries `{value, label?}` alongside plain
+strings. The canonical in-memory model keeps `missing_values` as a list of
+strings plus a side-car mapping of labels: the split (import) is shape-driven,
+never version-driven, and the export emits object entries if and only if at
+least one current value has a label.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple, Union
+
+IEntries = List[Union[str, Dict[str, str]]]
+
+PROFILE: Dict[str, Any] = {
+    "anyOf": [
+        {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["value"],
+                "properties": {
+                    "value": {"type": "string"},
+                    "label": {"type": "string"},
+                },
+            },
+        },
+    ],
+}
+
+
+def split(entries: IEntries) -> Tuple[List[str], Dict[str, str]]:
+    """Split entries into plain string values and a label mapping"""
+    labels = {
+        entry["value"]: entry["label"]
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("label") is not None
+    }
+    values = [entry["value"] if isinstance(entry, dict) else entry for entry in entries]
+    return values, labels
+
+
+def export(
+    values: List[str], labels: Dict[str, str]
+) -> Union[List[str], List[Dict[str, str]]]:
+    """Render the canonical descriptor form (objects iff at least one label)"""
+    if not any(value in labels for value in values):
+        return values
+    return [
+        (
+            {"value": value, "label": labels[value]}
+            if value in labels
+            else {"value": value}
+        )
+        for value in values
+    ]

--- a/frictionless/schema/missing_values.py
+++ b/frictionless/schema/missing_values.py
@@ -45,6 +45,29 @@ def split(entries: IEntries) -> Tuple[List[str], Dict[str, str]]:
     return values, labels
 
 
+def validation_notes(entries: IEntries) -> List[str]:
+    """Uniqueness notes for object entries (empty if valid)
+
+    Object entries must have a unique value and an optional unique label;
+    absent labels do not collide with each other. Plain string entries keep
+    the lax v1 behavior (duplicates allowed).
+    """
+    notes: List[str] = []
+    if not any(isinstance(entry, dict) for entry in entries):
+        return notes
+    values = [entry["value"] if isinstance(entry, dict) else entry for entry in entries]
+    for value in _duplicates(values):
+        notes.append(f'missing value "{value}" is not unique')
+    labels = [
+        entry["label"]
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("label") is not None
+    ]
+    for label in _duplicates(labels):
+        notes.append(f'missing value label "{label}" is not unique')
+    return notes
+
+
 def export(
     values: List[str], labels: Dict[str, str]
 ) -> Union[List[str], List[Dict[str, str]]]:
@@ -59,3 +82,14 @@ def export(
         )
         for value in values
     ]
+
+
+def _duplicates(values: List[str]) -> List[str]:
+    """Values appearing more than once, each reported once in order"""
+    seen: set[str] = set()
+    duplicates: List[str] = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    return duplicates

--- a/frictionless/schema/missing_values.py
+++ b/frictionless/schema/missing_values.py
@@ -9,7 +9,7 @@ least one current value has a label.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 IEntries = List[Union[str, Dict[str, str]]]
 
@@ -66,6 +66,20 @@ def validation_notes(entries: IEntries) -> List[str]:
     for label in _duplicates(labels):
         notes.append(f'missing value label "{label}" is not unique')
     return notes
+
+
+def version_gate_notes(entries: IEntries, version: Optional[str]) -> List[str]:
+    """Notes when object entries appear under an explicitly declared v1 schema
+
+    The object form `{value, label?}` is a datapackage v2 addition. It is
+    rejected only when the version is explicitly resolved to v1; an undeclared
+    version (`None`) stays lenient and accepts the v1 union v2 superset.
+    """
+    if version != "v1":
+        return []
+    if not any(isinstance(entry, dict) for entry in entries):
+        return []
+    return ["missing values in object form require datapackage v2"]
 
 
 def export(

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -397,6 +397,12 @@ class Schema(Metadata, metaclass=Factory):
                 note = note % (pk, field_names)
                 yield errors.SchemaError(note=note)
 
+        # Missing Values
+        for note in missing_values_module.validation_notes(
+            descriptor.get("missingValues", [])
+        ):
+            yield errors.SchemaError(note=note)
+
         # Foreign Keys
         fks = descriptor.get("foreignKeys", [])
         for fk in fks:

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -84,6 +84,18 @@ class Schema(Metadata, metaclass=Factory):
     Specifies the foreign keys for the schema.
     """
 
+    def __setattr__(self, name: str, value: Any):  # type: ignore
+        if name == "missing_values" and isinstance(value, list):
+            self._missing_values_labels = {
+                item["value"]: item["label"]
+                for item in value
+                if isinstance(item, dict) and item.get("label") is not None
+            }
+            value = [
+                item["value"] if isinstance(item, dict) else item for item in value
+            ]
+        return super().__setattr__(name, value)  # type: ignore
+
     def __attrs_post_init__(self):
         for field in self.fields:
             field.schema = self
@@ -299,8 +311,23 @@ class Schema(Metadata, metaclass=Factory):
             "description": {"type": "string"},
             "fields": {"type": "array"},
             "missingValues": {
-                "type": "array",
-                "items": {"type": "string"},
+                "anyOf": [
+                    {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["value"],
+                            "properties": {
+                                "value": {"type": "string"},
+                                "label": {"type": "string"},
+                            },
+                        },
+                    },
+                ],
             },
             "primaryKey": {
                 "type": "array",

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Union, cast
 
 import attrs
 from tabulate import tabulate
@@ -9,6 +9,7 @@ from .. import errors, settings, types
 from ..exception import FrictionlessException
 from ..metadata import Metadata
 from ..platform import platform
+from . import missing_values as missing_values_module
 from .factory import Factory
 from .field import Field
 from .types import INotes
@@ -86,14 +87,9 @@ class Schema(Metadata, metaclass=Factory):
 
     def __setattr__(self, name: str, value: Any):  # type: ignore
         if name == "missing_values" and isinstance(value, list):
-            self._missing_values_labels = {
-                item["value"]: item["label"]
-                for item in value
-                if isinstance(item, dict) and item.get("label") is not None
-            }
-            value = [
-                item["value"] if isinstance(item, dict) else item for item in value
-            ]
+            value, self._missing_values_labels = missing_values_module.split(
+                cast(missing_values_module.IEntries, value)
+            )
         return super().__setattr__(name, value)  # type: ignore
 
     def __attrs_post_init__(self):
@@ -310,25 +306,7 @@ class Schema(Metadata, metaclass=Factory):
             "title": {"type": "string"},
             "description": {"type": "string"},
             "fields": {"type": "array"},
-            "missingValues": {
-                "anyOf": [
-                    {
-                        "type": "array",
-                        "items": {"type": "string"},
-                    },
-                    {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["value"],
-                            "properties": {
-                                "value": {"type": "string"},
-                                "label": {"type": "string"},
-                            },
-                        },
-                    },
-                ],
-            },
+            "missingValues": missing_values_module.PROFILE,
             "primaryKey": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -382,6 +360,18 @@ class Schema(Metadata, metaclass=Factory):
                     fk["fields"] = [fk["fields"]]
                 if not isinstance(fk["reference"]["fields"], list):
                     fk["reference"]["fields"] = [fk["reference"]["fields"]]
+
+    def metadata_export(self, *, exclude: List[str] = []) -> types.IDescriptor:
+        descriptor = super().metadata_export(exclude=exclude)
+
+        missing_values = descriptor.get("missingValues")
+        if isinstance(missing_values, list):
+            descriptor["missingValues"] = missing_values_module.export(
+                cast(List[str], missing_values),
+                getattr(self, "_missing_values_labels", {}),
+            )
+
+        return descriptor
 
     @classmethod
     def metadata_validate(cls, descriptor: types.IDescriptor):  # type: ignore

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -398,10 +398,21 @@ class Schema(Metadata, metaclass=Factory):
                 yield errors.SchemaError(note=note)
 
         # Missing Values
-        for note in missing_values_module.validation_notes(
-            descriptor.get("missingValues", [])
-        ):
+        missing_values = descriptor.get("missingValues", [])
+        for note in missing_values_module.validation_notes(missing_values):
             yield errors.SchemaError(note=note)
+
+        # Missing Values version gate
+        # Read `$schema` directly: the version is only gated when explicitly
+        # declared (an absent `$schema` stays lenient), and `$schema` is still
+        # in the descriptor at validation time (popped later, in metadata_import).
+        schema_profile = descriptor.get("$schema")
+        if schema_profile:
+            version = cls._resolve_datapackage_version(schema_profile)
+            for note in missing_values_module.version_gate_notes(
+                missing_values, version
+            ):
+                yield errors.SchemaError(note=note)
 
         # Foreign Keys
         fks = descriptor.get("foreignKeys", [])

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -322,7 +322,10 @@ class Schema(Metadata, metaclass=Factory):
                             "required": ["resource", "fields"],
                             "properties": {
                                 "resource": {"type": "string"},
-                                "fields": {"type": "array", "items": {"type": "string"}},
+                                "fields": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
                             },
                         },
                     },
@@ -374,8 +377,15 @@ class Schema(Metadata, metaclass=Factory):
         return descriptor
 
     @classmethod
-    def metadata_validate(cls, descriptor: types.IDescriptor):  # type: ignore
-        metadata_errors = list(super().metadata_validate(descriptor))
+    def metadata_validate(  # type: ignore
+        cls,
+        descriptor: types.IDescriptor,
+        *,
+        datapackage_version: Optional[types.IStandards] = None,
+    ):
+        metadata_errors = list(
+            super().metadata_validate(descriptor, datapackage_version=datapackage_version)
+        )
         if metadata_errors:
             yield from metadata_errors
             return
@@ -403,16 +413,11 @@ class Schema(Metadata, metaclass=Factory):
             yield errors.SchemaError(note=note)
 
         # Missing Values version gate
-        # Read `$schema` directly: the version is only gated when explicitly
-        # declared (an absent `$schema` stays lenient), and `$schema` is still
-        # in the descriptor at validation time (popped later, in metadata_import).
-        schema_profile = descriptor.get("$schema")
-        if schema_profile:
-            version = cls._resolve_datapackage_version(schema_profile)
-            for note in missing_values_module.version_gate_notes(
-                missing_values, version
-            ):
-                yield errors.SchemaError(note=note)
+        # The version is the one imposed top-down by an ancestor's `$schema`, or
+        # this schema's own `$schema` otherwise; `None` (undeclared) stays lenient.
+        version = cls.effective_datapackage_version(descriptor, datapackage_version)
+        for note in missing_values_module.version_gate_notes(missing_values, version):
+            yield errors.SchemaError(note=note)
 
         # Foreign Keys
         fks = descriptor.get("foreignKeys", [])


### PR DESCRIPTION
Allow for DPv2 missing values as objects with labels. 

Features : 

# Global architecture approach

- Class deserializing support the superset of v1 and v2
- Class properties are as most as possible only v2 properties, not storing the initial version if read from a descriptor. Round-trip of deserializing and reserializing will therefore return a canonical descriptor, possibly different from original input. This canonical form is however, idempotent (deserializing and reserializing gives the same descriptor). 
- Class validation however needs to know the version (possibly inherited) to validate accordingly

# Descriptor validation

- implementation handles v1 and v2. Validation triggers an error if using objects with explicit v1. Lenient validation : if no $schema is provided, no error is reported (despite the DP reference stating that default value is v1). Custom schemas/profiles are considered v2 by default.  
- Unicity of values and labels validated
  - Unicity of "strings" in case of a list of strings is not validated, as this would be a non-essential breaking change

# Sidenote 

Reference does not seem to explicitely forbid that `Package` and `Schema` have contradicting `$schema` properties. However, this should not be a feature, so current implementation gives precedence on the parent's version. 

# TODO

- [x] Version inheritence in metadata_validate