### PR TITLE
fix: resolve string aggfun to callable in table_pivot step

### DIFF
--- a/frictionless/steps/table/__spec__/test_table_pivot.py
+++ b/frictionless/steps/table/__spec__/test_table_pivot.py
@@ -24,3 +24,33 @@ def test_step_table_pivot_issue_1220():
         {"region": "east", "boy": 33, "girl": 29},
         {"region": "west", "boy": 35, "girl": 23},
     ]
+
+
+def test_step_table_pivot_string_aggfun_issue_1764():
+    source = TableResource(path="data/transform-pivot.csv")
+    pipeline = Pipeline.from_descriptor(
+        {
+            "steps": [
+                {"type": "table-normalize"},
+                {
+                    "type": "table-pivot",
+                    "f1": "region",
+                    "f2": "gender",
+                    "f3": "units",
+                    "aggfun": "sum",
+                },
+            ]
+        }
+    )
+    target = source.transform(pipeline)
+    assert target.schema.to_descriptor() == {
+        "fields": [
+            {"name": "region", "type": "string"},
+            {"name": "boy", "type": "integer"},
+            {"name": "girl", "type": "integer"},
+        ]
+    }
+    assert target.read_rows() == [
+        {"region": "east", "boy": 33, "girl": 29},
+        {"region": "west", "boy": 35, "girl": 23},
+    ]

--- a/frictionless/steps/table/table_pivot.py
+++ b/frictionless/steps/table/table_pivot.py
@@ -1,14 +1,32 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import statistics
+from typing import TYPE_CHECKING, Any, Callable
 
 import attrs
 
+from ... import errors
+from ...exception import FrictionlessException
 from ...pipeline import Step
 from ...schema import Schema
 
 if TYPE_CHECKING:
     from ...resource import Resource
+
+
+# Mapping of petl aggregation function names to callables. This allows a
+# string `aggfun` (e.g. coming from a JSON/YAML descriptor) to mirror the
+# Python API, where a callable is passed directly.
+AGGREGATION_FUNCTIONS: dict[str, Callable[[Any], Any]] = {
+    "sum": sum,
+    "max": max,
+    "min": min,
+    "len": len,
+    "count": len,
+    "mean": statistics.mean,
+    "first": lambda values: list(values)[0],
+    "last": lambda values: list(values)[-1],
+}
 
 
 @attrs.define(kw_only=True, repr=False)
@@ -40,14 +58,22 @@ class table_pivot(Step):
     aggfun: Any
     """
     Function to process and create data in the output pivot table.
-    The function can be "sum", "max", "min", "len" etc.
+    It can be a callable or, when defined via a descriptor, one of the
+    supported aggregation function names: "sum", "max", "min", "len",
+    "count", "mean", "first", "last".
     """
 
     # Transform
 
     def transform_resource(self, resource: Resource):
         table = resource.to_petl()  # type: ignore
-        resource.data = table.pivot(self.f1, self.f2, self.f3, self.aggfun)  # type: ignore
+        aggfun = self.aggfun
+        if isinstance(aggfun, str):
+            if aggfun not in AGGREGATION_FUNCTIONS:
+                note = f'aggregation function "{aggfun}" is not supported'
+                raise FrictionlessException(errors.StepError(note=note))
+            aggfun = AGGREGATION_FUNCTIONS[aggfun]
+        resource.data = table.pivot(self.f1, self.f2, self.f3, aggfun)  # type: ignore
         resource.schema = Schema()
         resource.infer()
 


### PR DESCRIPTION
- fixes #1764

---

## Summary

A `table-pivot` step defined via a JSON/YAML descriptor with `"aggfun": "sum"` fails, while the equivalent Python API `steps.table_pivot(..., aggfun=sum)` works, even though the docs (and the step's own docstring) say descriptors mirror the Python API and that `aggfun` "can be `sum`, `max`, `min`, `len` etc.".

Reproducer from the issue:

```python
json_descriptor = {
    "steps": [
        {"type": "table-normalize"},
        {"type": "table-pivot", "f1": "region", "f2": "gender", "f3": "units", "aggfun": "sum"},
    ]
}
Resource(data=data).transform(Pipeline.from_descriptor(json_descriptor))
```

fails with:

```
FrictionlessException: [step-error] Step is not valid: "table_pivot" raises
"[source-error] ... 'str' object is not callable"
```

**Root cause:** `aggfun` is typed `Any` with an empty metadata profile, so a JSON string like `"sum"` passes validation and is handed straight to petl's `table.pivot(f1, f2, f3, aggfun)`, which requires a **callable**, not a string.

## Fix

In `frictionless/steps/table/table_pivot.py`, `transform_resource` now resolves a string `aggfun` to the corresponding callable before calling `petl.pivot`, via a small map of the standard petl aggregation names:

`sum`, `max`, `min`, `len`, `count` (alias for `len`), `mean` (`statistics.mean`), `first`, `last`.

An actual callable `aggfun` is passed through unchanged (the existing Python-API behavior). An unrecognized name raises a clear `StepError` (`aggregation function "<name>" is not supported`) instead of the opaque petl `TypeError`. The docstring was updated to list the supported names.

## Tests

Added `test_step_table_pivot_string_aggfun_issue_1764` in `frictionless/steps/table/__spec__/test_table_pivot.py`, mirroring the existing `test_step_table_pivot_issue_1220` but building the pipeline from a descriptor with `"aggfun": "sum"`. It fails on `main` (`'str' object is not callable`) and passes with this change. Full `frictionless/steps`, `frictionless/pipeline`, and `frictionless/transformer` suites pass; `ruff check`, `ruff format --check`, and `pyright` are clean on the changed files.

## Note on scope

This fixes the descriptor -> callable (input) direction, which is the reported failure and matches the documented usage. The issue also mentions that `pipeline.to_json()` fails when a Python **callable** was passed directly (e.g. the builtin `sum`), because a function is not JSON serializable. Reliably serializing an arbitrary callable back to a descriptor name is a separate design decision (lambdas / user functions have no canonical name), so it is intentionally left out here; using a string `aggfun` in the descriptor now round-trips cleanly through `to_json`/`from_descriptor`.

Disclosure: prepared with AI assistance; reviewed and verified locally.