### PR TITLE
fix: reject unsafe package metadata paths

### DIFF
--- a/frictionless/package/__spec__/test_security.py
+++ b/frictionless/package/__spec__/test_security.py
@@ -6,6 +6,63 @@ from frictionless import FrictionlessException, Package, Resource, platform, sys
 
 # General
 
+DP_PROFILES = [
+    "https://datapackage.org/profiles/1.0/datapackage.json",
+    "https://datapackage.org/profiles/2.0/datapackage.json",
+]
+UNSAFE_METADATA_PATHS = [
+    "/outside/image.png",
+    r"C:\outside\image.png",
+    r"\\server\share\image.png",
+    "../outside/image.png",
+    "file:///outside/image.png",
+    "s3://bucket/image.png",
+    "javascript:alert(1)",
+    "mailto:user@example.com",
+    "unknown://host/image.png",
+    "http://[",
+]
+SAFE_METADATA_PATHS = [
+    "assets/image.png",
+    "http://example.com/image.png",
+    "https://example.com/image.png",
+    "ftp://example.com/image.png",
+    "ftps://example.com/image.png",
+]
+
+
+def _package_with_metadata_path(field, path):
+    descriptor = {"resources": []}
+    if field == "image":
+        descriptor["image"] = path
+    else:
+        name = {
+            "contributor": "contributors",
+            "license": "licenses",
+            "source": "sources",
+        }[field]
+        descriptor[name] = [{"title": field.title(), "path": path}]
+    return descriptor
+
+
+@pytest.mark.parametrize("schema", DP_PROFILES)
+@pytest.mark.parametrize("field", ["image", "contributor", "license", "source"])
+@pytest.mark.parametrize("path", UNSAFE_METADATA_PATHS)
+def test_package_rejects_unsafe_metadata_paths_issue_1591(schema, field, path):
+    descriptor = _package_with_metadata_path(field, path)
+    descriptor["$schema"] = schema
+    errors = list(Package.metadata_validate(descriptor))
+    assert [error.note for error in errors] == [f'path "{path}" is not safe']
+
+
+@pytest.mark.parametrize("schema", DP_PROFILES)
+@pytest.mark.parametrize("field", ["image", "contributor", "license", "source"])
+@pytest.mark.parametrize("path", SAFE_METADATA_PATHS)
+def test_package_accepts_safe_metadata_paths_issue_1591(schema, field, path):
+    descriptor = _package_with_metadata_path(field, path)
+    descriptor["$schema"] = schema
+    assert not list(Package.metadata_validate(descriptor))
+
 
 @pytest.mark.skipif(platform.type == "windows", reason="Fix on Windows")
 def test_package_resource_unsafe_schema():

--- a/frictionless/package/package.py
+++ b/frictionless/package/package.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from multiprocessing import Pool
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
+from urllib.parse import urlparse
 
 import attrs
 from typing_extensions import Self
@@ -674,6 +676,8 @@ class Package(Metadata, metaclass=Factory):
 
         # Security
         if not system.trusted:
+            from ..schemes.remote import settings as remote_settings
+
             keys = ["profile"]
             for key in keys:
                 value = descriptor.get(key)
@@ -682,6 +686,30 @@ class Package(Metadata, metaclass=Factory):
                     if item and isinstance(item, str) and not helpers.is_safe_path(item):
                         yield errors.PackageError(note=f'path "{item}" is not safe')
                         return
+
+            paths = [descriptor.get("image")]
+            for name in ["contributors", "licenses", "sources"]:
+                paths.extend(item.get("path") for item in descriptor.get(name, []))
+            for path in paths:
+                if not path:
+                    continue
+                posix_path = PurePosixPath(path.replace("\\", "/"))
+                is_absolute = (
+                    posix_path.is_absolute() or PureWindowsPath(path).is_absolute()
+                )
+                try:
+                    scheme = urlparse(path).scheme
+                except ValueError:
+                    yield errors.PackageError(note=f'path "{path}" is not safe')
+                    continue
+                is_remote = scheme in remote_settings.DEFAULT_SCHEMES
+                if not is_remote and (
+                    scheme
+                    or is_absolute
+                    or ".." in posix_path.parts
+                    or not helpers.is_safe_path(path)
+                ):
+                    yield errors.PackageError(note=f'path "{path}" is not safe')
 
         # Resource Names
         resource_names: List[str] = []


### PR DESCRIPTION
- fixes #1591

## Summary

- reject absolute, parent-relative, UNC, drive-qualified, and unsupported-scheme paths in package metadata
- cover `image` as well as the equivalent `path` fields in contributors, licenses, and sources
- preserve the supported remote scheme allowlist and report malformed URLs as validation errors

## Root cause

`Package.metadata_validate()` checked unsafe resource schema paths in untrusted mode, but it did not apply equivalent checks to package-level metadata paths. As a result, local absolute or parent-relative paths and unsupported schemes could pass validation. A malformed URL could also escape validation by raising `ValueError` from `urlparse()`.

## Validation

- `python -m pytest frictionless/package/__spec__/test_security.py -q` — 122 passed, 2 skipped
- `python -m ruff check frictionless/package/package.py frictionless/package/__spec__/test_security.py`
- `python -m ruff format --check frictionless/package/package.py frictionless/package/__spec__/test_security.py`
- `git diff --check`

An additional run of the full `frictionless/package/__spec__` directory was attempted, but it exceeded a 120-second local limit without reporting an assertion failure. The focused 124-case security module completed successfully.

## AI disclosure

This Draft PR was prepared and validated by an automated AI coding agent. The agent identified the root cause, produced the patch and tests, ran the checks listed above, and opened this Draft PR. It has not yet received human or maintainer review.
