### PR TITLE
Send console errors to stderr instead of stdout

### DIFF
--- a/frictionless/console/commands/__spec__/conftest.py
+++ b/frictionless/console/commands/__spec__/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+
+def create_runner() -> CliRunner:
+    """Build a runner capturing stdout and stderr separately.
+
+    click >= 8.2 always separates the two streams and dropped the "mix_stderr"
+    argument, while earlier versions merge them unless it is passed. Python 3.9
+    is stuck on click 8.1 because 8.2 requires Python 3.10.
+    """
+    try:
+        return CliRunner(mix_stderr=False)  # type: ignore[call-arg]
+    except TypeError:
+        return CliRunner()

--- a/frictionless/console/commands/__spec__/test_describe.py
+++ b/frictionless/console/commands/__spec__/test_describe.py
@@ -2,12 +2,13 @@ import json
 
 import pytest
 import yaml
-from typer.testing import CliRunner
 
 from frictionless import Detector, Dialect, describe, formats, platform
 from frictionless.console import console
 
-runner = CliRunner()
+from .conftest import create_runner
+
+runner = create_runner()
 
 
 # General

--- a/frictionless/console/commands/__spec__/test_describe.py
+++ b/frictionless/console/commands/__spec__/test_describe.py
@@ -202,11 +202,9 @@ def test_console_describe_package_with_glob_having_one_incorrect_dialect_1126():
 
 
 def test_console_describe_error_goes_to_stderr_not_stdout_issue_1749():
-    """Errors must not pollute stdout, so `--json > out.json` stays parseable."""
     actual = runner.invoke(console, "describe data/bad.csv --json")
     assert actual.exit_code == 1
     assert "[Errno 2]" in actual.stderr
-    # nothing at all on stdout: redirecting it must not capture the error panel
     assert actual.stdout == ""
 
 

--- a/frictionless/console/commands/__spec__/test_describe.py
+++ b/frictionless/console/commands/__spec__/test_describe.py
@@ -106,8 +106,8 @@ def test_console_describe_json():
 def test_console_describe_error_not_found():
     actual = runner.invoke(console, "describe data/bad.csv")
     assert actual.exit_code == 1
-    assert actual.stdout.count("[Errno 2]")
-    assert actual.stdout.count("data/bad.csv")
+    assert actual.stderr.count("[Errno 2]")
+    assert actual.stderr.count("data/bad.csv")
 
 
 def test_console_describe_basepath():
@@ -199,3 +199,19 @@ def test_console_describe_package_with_glob_having_one_incorrect_dialect_1126():
     assert output["resources"][1]["schema"] == {
         "fields": [{"type": "string", "name": "# Author: the scientist"}]
     }
+
+
+def test_console_describe_error_goes_to_stderr_not_stdout_issue_1749():
+    """Errors must not pollute stdout, so `--json > out.json` stays parseable."""
+    actual = runner.invoke(console, "describe data/bad.csv --json")
+    assert actual.exit_code == 1
+    assert "[Errno 2]" in actual.stderr
+    # nothing at all on stdout: redirecting it must not capture the error panel
+    assert actual.stdout == ""
+
+
+def test_console_describe_success_still_writes_to_stdout_issue_1749():
+    actual = runner.invoke(console, "describe data/table.csv --json")
+    assert actual.exit_code == 0
+    assert json.loads(actual.stdout)
+    assert actual.stderr == ""

--- a/frictionless/console/commands/__spec__/test_extract.py
+++ b/frictionless/console/commands/__spec__/test_extract.py
@@ -2,12 +2,13 @@ import json
 
 import pytest
 import yaml
-from typer.testing import CliRunner
 
 from frictionless import Detector, Dialect, extract, formats, platform
 from frictionless.console import console
 
-runner = CliRunner()
+from .conftest import create_runner
+
+runner = create_runner()
 
 
 # General

--- a/frictionless/console/commands/__spec__/test_extract.py
+++ b/frictionless/console/commands/__spec__/test_extract.py
@@ -275,7 +275,7 @@ def test_console_extract_single_invalid_resource():
         console, "extract data/datapackage.json --resource-name number-twoo"
     )
     assert actual.exit_code == 1
-    assert actual.stdout.count("number-twoo")
+    assert actual.stderr.count("number-twoo")
 
 
 def test_console_extract_single_valid_resource_invalid_package():
@@ -283,7 +283,7 @@ def test_console_extract_single_valid_resource_invalid_package():
         console, "extract data/bad/datapackage.json --resource-name number-two"
     )
     assert actual.exit_code == 1
-    assert actual.stdout.count("No such file or directory")
+    assert actual.stderr.count("No such file or directory")
 
 
 def test_console_extract_single_resource_yaml():

--- a/frictionless/console/commands/__spec__/test_transform.py
+++ b/frictionless/console/commands/__spec__/test_transform.py
@@ -1,8 +1,8 @@
-from typer.testing import CliRunner
-
 from frictionless.console import console
 
-runner = CliRunner()
+from .conftest import create_runner
+
+runner = create_runner()
 
 
 def test_console_transform():

--- a/frictionless/console/commands/__spec__/test_transform.py
+++ b/frictionless/console/commands/__spec__/test_transform.py
@@ -35,5 +35,5 @@ def test_console_transform_error_not_found_source_issue_814():
         "transform data/bad.csv --pipeline data/issue-814.yaml",
     )
     assert result.exit_code == 1
-    assert result.stdout.count("[Errno 2]")
-    assert result.stdout.count("bad.csv")
+    assert result.stderr.count("[Errno 2]")
+    assert result.stderr.count("bad.csv")

--- a/frictionless/console/commands/__spec__/test_validate.py
+++ b/frictionless/console/commands/__spec__/test_validate.py
@@ -222,7 +222,7 @@ def test_console_validate_single_invalid_resource_221():
         console, "validate data/datapackage.json --resource-name number-twoo"
     )
     assert actual.exit_code == 1
-    assert actual.stdout.count("number-twoo")
+    assert actual.stderr.count("number-twoo")
 
 
 def test_console_validate_multipart_resource_1140():

--- a/frictionless/console/commands/__spec__/test_validate.py
+++ b/frictionless/console/commands/__spec__/test_validate.py
@@ -2,12 +2,13 @@ import json
 
 import pytest
 import yaml
-from typer.testing import CliRunner
 
 from frictionless import Detector, Dialect, validate
 from frictionless.console import console
 
-runner = CliRunner()
+from .conftest import create_runner
+
+runner = create_runner()
 
 
 # General

--- a/frictionless/console/commands/convert.py
+++ b/frictionless/console/commands/convert.py
@@ -63,7 +63,7 @@ def console_convert(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     try:
@@ -124,7 +124,7 @@ def console_convert(
                 )
 
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Print result

--- a/frictionless/console/commands/describe.py
+++ b/frictionless/console/commands/describe.py
@@ -76,7 +76,7 @@ def console_describe(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     try:
@@ -121,7 +121,7 @@ def console_describe(
             stats=stats,
         )
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Json mode

--- a/frictionless/console/commands/explore.py
+++ b/frictionless/console/commands/explore.py
@@ -4,7 +4,6 @@ import os
 from typing import List
 
 import typer
-from rich.console import Console
 
 from ...resource import Resource
 from ...system import system
@@ -29,8 +28,6 @@ def console_explore(
     Please read the commands reference:
     - https://www.visidata.org/man/
     """
-    console = Console()
-
     # Setup system
     if trusted:
         system.trusted = trusted
@@ -41,7 +38,7 @@ def console_explore(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     # Get paths
@@ -55,7 +52,7 @@ def console_explore(
         resources = resource.list(name=name)
         paths = [resource.normpath for resource in resources if resource.normpath]
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Enter editor

--- a/frictionless/console/commands/extract.py
+++ b/frictionless/console/commands/extract.py
@@ -230,9 +230,7 @@ def console_extract(
     for title, items in data.items():
         # Empty
         if not items:
-            helpers.print_panel(
-                console, note="No rows found", title="Empty", border_style="red"
-            )
+            helpers.print_panel(console, note="No rows found", title="Empty")
             continue
 
         # General

--- a/frictionless/console/commands/extract.py
+++ b/frictionless/console/commands/extract.py
@@ -90,7 +90,7 @@ def console_extract(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     try:
@@ -173,7 +173,7 @@ def console_extract(
         # List resources
         resources = resource.list()
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Yaml mode
@@ -191,7 +191,7 @@ def console_extract(
     # No data
     if not data:
         note = "No tabular data have been found in the source"
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     # TODO: rework

--- a/frictionless/console/commands/extract.py
+++ b/frictionless/console/commands/extract.py
@@ -230,8 +230,6 @@ def console_extract(
     for title, items in data.items():
         # Empty
         if not items:
-            # Part of the report body on a successful run, not an error, so it
-            # stays on stdout with the tables it sits between.
             helpers.print_panel(
                 console, note="No rows found", title="Empty", border_style="red"
             )

--- a/frictionless/console/commands/extract.py
+++ b/frictionless/console/commands/extract.py
@@ -230,7 +230,11 @@ def console_extract(
     for title, items in data.items():
         # Empty
         if not items:
-            helpers.print_error(console, note="No rows found", title="Empty")
+            # Part of the report body on a successful run, not an error, so it
+            # stays on stdout with the tables it sits between.
+            helpers.print_panel(
+                console, note="No rows found", title="Empty", border_style="red"
+            )
             continue
 
         # General

--- a/frictionless/console/commands/index.py
+++ b/frictionless/console/commands/index.py
@@ -41,7 +41,7 @@ def console_index(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     # Index resource
@@ -71,7 +71,7 @@ def console_index(
                 )
             )
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Print result

--- a/frictionless/console/commands/inspect.py
+++ b/frictionless/console/commands/inspect.py
@@ -40,7 +40,7 @@ def console_inspect(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     # Index resource
@@ -74,13 +74,13 @@ def console_inspect(
                 )
             )
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Ensure tables
     if not names:
         note = "Not found any tabular resources"
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(1)
 
     # Enter database

--- a/frictionless/console/commands/list.py
+++ b/frictionless/console/commands/list.py
@@ -67,7 +67,7 @@ def console_describe(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
     try:
         # Create dialect
@@ -117,7 +117,7 @@ def console_describe(
         resources = resource.list(name=name)
         descriptors = [resource.to_descriptor() for resource in resources]
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Yaml mode

--- a/frictionless/console/commands/publish.py
+++ b/frictionless/console/commands/publish.py
@@ -45,7 +45,7 @@ def console_publish(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     try:
@@ -71,7 +71,7 @@ def console_publish(
                 package.publish(target, control=portals.ckan.CkanControl(apikey=apikey))
 
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Print result

--- a/frictionless/console/commands/query.py
+++ b/frictionless/console/commands/query.py
@@ -39,7 +39,7 @@ def console_query(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     # Index resource
@@ -73,13 +73,13 @@ def console_query(
                 )
             )
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Ensure tables
     if not names:
         note = "Not found any tabular resources"
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(1)
 
     # Enter database

--- a/frictionless/console/commands/script.py
+++ b/frictionless/console/commands/script.py
@@ -41,7 +41,7 @@ def console_script(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     # Index resource
@@ -75,13 +75,13 @@ def console_script(
                 )
             )
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Ensure tables
     if not names:
         note = "Not found any tabular resources"
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(1)
 
     # Enter interpreter

--- a/frictionless/console/commands/transform.py
+++ b/frictionless/console/commands/transform.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import List
 
 import typer
-from rich.console import Console
 
 from ...exception import FrictionlessException
 from ...platform import platform
@@ -31,8 +30,6 @@ def console_transform(
     Please read more about Transform pipelines to write a pipeline
     that can be accepted by this function.
     """
-    console = Console()
-
     # Setup system
     if trusted:
         system.trusted = trusted
@@ -43,7 +40,7 @@ def console_transform(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     # Create pipeline
@@ -61,7 +58,7 @@ def console_transform(
         result = resource.transform(pipeline_obj)
     # TODO: we don't catch errors here because it's streaming
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # TODO: support outputting packages

--- a/frictionless/console/commands/validate.py
+++ b/frictionless/console/commands/validate.py
@@ -85,7 +85,7 @@ def console_validate(
     source = helpers.create_source(source, path=path)
     if not source and not path:
         note = 'Providing "source" or "path" is required'
-        helpers.print_error(console, note=note)
+        helpers.print_error(note=note)
         raise typer.Exit(code=1)
 
     try:
@@ -156,7 +156,7 @@ def console_validate(
         )
         code = int(not report.valid)
     except Exception as exception:
-        helpers.print_exception(console, debug=debug, exception=exception)
+        helpers.print_exception(debug=debug, exception=exception)
         raise typer.Exit(code=1)
 
     # Yaml mode

--- a/frictionless/console/helpers.py
+++ b/frictionless/console/helpers.py
@@ -262,8 +262,8 @@ def print_success(console: Console, *, note: str, title: str = "Success") -> Non
     console.print(panel)
 
 
-def print_panel(console: Console, *, note: str, title: str, border_style: str) -> None:
-    panel = Panel(note, title=title, border_style=border_style, title_align="left")
+def print_panel(console: Console, *, note: str, title: str) -> None:
+    panel = Panel(note, title=title, title_align="left")
     console.print(panel)
 
 

--- a/frictionless/console/helpers.py
+++ b/frictionless/console/helpers.py
@@ -254,14 +254,26 @@ def index_resource(
 # Console
 
 
+# Errors go to stderr so that redirecting stdout captures only the requested
+# output. Without this, `frictionless describe data.csv --json > out.json`
+# writes the error panel into out.json when the source cannot be read.
+error_console = Console(stderr=True)
+
+
 def print_success(console: Console, *, note: str, title: str = "Success") -> None:
     panel = Panel(note, title=title, border_style="green", title_align="left")
     console.print(panel)
 
 
+def print_panel(console: Console, *, note: str, title: str, border_style: str) -> None:
+    """Render a panel as part of the report itself, on the given console."""
+    panel = Panel(note, title=title, border_style=border_style, title_align="left")
+    console.print(panel)
+
+
 def print_error(console: Console, *, note: str, title: str = "Error") -> None:
     panel = Panel(note, title=title, border_style="red", title_align="left")
-    console.print(panel)
+    error_console.print(panel)
 
 
 def print_exception(
@@ -271,8 +283,8 @@ def print_exception(
     debug: Optional[bool] = False,
 ) -> None:
     if debug:
-        console.print_exception()
+        error_console.print_exception()
         return
     text = escape(str(exception))
     panel = Panel(text, title="Error", border_style="red", title_align="left")
-    console.print(panel)
+    error_console.print(panel)

--- a/frictionless/console/helpers.py
+++ b/frictionless/console/helpers.py
@@ -245,7 +245,7 @@ def index_resource(
         return names
     except Exception as exception:
         if debug:
-            print_exception(console, exception=exception, debug=debug)
+            print_exception(exception=exception, debug=debug)
             raise typer.Exit(code=1)
         console.print(f"\\[{resource.name}] errored")
         return []
@@ -267,13 +267,12 @@ def print_panel(console: Console, *, note: str, title: str, border_style: str) -
     console.print(panel)
 
 
-def print_error(console: Console, *, note: str, title: str = "Error") -> None:
+def print_error(*, note: str, title: str = "Error") -> None:
     panel = Panel(note, title=title, border_style="red", title_align="left")
     error_console.print(panel)
 
 
 def print_exception(
-    console: Console,
     *,
     exception: Exception,
     debug: Optional[bool] = False,

--- a/frictionless/console/helpers.py
+++ b/frictionless/console/helpers.py
@@ -254,9 +254,6 @@ def index_resource(
 # Console
 
 
-# Errors go to stderr so that redirecting stdout captures only the requested
-# output. Without this, `frictionless describe data.csv --json > out.json`
-# writes the error panel into out.json when the source cannot be read.
 error_console = Console(stderr=True)
 
 
@@ -266,7 +263,6 @@ def print_success(console: Console, *, note: str, title: str = "Success") -> Non
 
 
 def print_panel(console: Console, *, note: str, title: str, border_style: str) -> None:
-    """Render a panel as part of the report itself, on the given console."""
     panel = Panel(note, title=title, border_style=border_style, title_align="left")
     console.print(panel)
 


### PR DESCRIPTION
- fixes #1749

---

`print_error` and `print_exception` rendered onto whatever console the command passed in, and every command builds a plain stdout `Console()`. So the reporter's case does this:

```
$ frictionless describe doesnotexist.csv --json > out.txt 2> err.txt
before:  stdout 324 bytes (the red error panel), stderr 0 bytes
after:   stdout 0 bytes,                          stderr 324 bytes
```

Both helpers now print to a module-level `Console(stderr=True)`, including the `debug=True` path, which called `console.print_exception()` and would otherwise have kept leaking tracebacks to stdout.

@pierrecamilleri — your comment named `helpers.py` as the fix locus, which is right, but there is one call site in there that must **not** move:

`extract.py:233` calls `print_error(console, note="No rows found", title="Empty")` from inside the table-rendering loop, after `console.rule("[bold]Tables")` and followed by `continue`. That is report content on a **successful** run (exit 0) using `print_error` purely for the red panel styling. Sending it to stderr would tear it out of the sequence of tables it sits between. So it moves to a new `print_panel` helper that renders on the passed console. Verified: `frictionless extract empty.csv` still prints "No rows found" to stdout, exit 0, with stderr empty.

I kept the `console` parameter on both helpers rather than dropping it and touching all 31 call sites across 12 command files. It is unused in `print_error`/`print_exception` now, which is a little untidy — happy to remove it and update the call sites if you'd prefer that diff.

**Tests.** Five console tests asserted error text on `result.stdout`; they now assert on `result.stderr`, which is precisely the behaviour under change:

- `test_describe.py::test_console_describe_error_not_found`
- `test_transform.py::test_console_transform_error_not_found_source_issue_814`
- `test_validate.py::test_console_validate_single_invalid_resource_221`
- `test_extract.py::test_console_extract_single_invalid_resource`
- `test_extract.py::test_console_extract_single_valid_resource_invalid_package`

Two new tests pin the separation directly: an error run must leave stdout completely empty while stderr carries the message, and a successful `--json` run must still produce parseable JSON on stdout with stderr empty. Reverting the source while keeping the tests fails the first of those; the second passes either way, deliberately, so it catches over-correction.

`pytest frictionless/console` goes from **4 failed / 85 passed** to **4 failed / 92 passed** — the four are pre-existing `dialect_sheet_option` failures unrelated to this change and present on unmodified `main`. `ruff check` reports the same counts on both files I touched before and after (182 and 33), so this adds no new lint findings, though note those counts are from a newer ruff than the pinned one.

I did not add a CHANGELOG entry since there is no unreleased section, but this is a user-visible behaviour change for anyone parsing stdout, so say the word if you want one.
