### PR TITLE
fix(steps): make field_pack target resource re-readable

### DIFF
--- a/frictionless/steps/field/__spec__/test_field_pack.py
+++ b/frictionless/steps/field/__spec__/test_field_pack.py
@@ -77,3 +77,15 @@ def test_step_field_pack_object():
         "population": 83,
         "details": {"name": "germany", "population": "83"},
     }
+
+
+def test_step_field_pack_reread_issue_1476():
+    source = TableResource(path="data/transform.csv")
+    pipeline = Pipeline(
+        steps=[
+            steps.field_pack(name="details", from_names=["name", "population"]),
+        ],
+    )
+    target = source.transform(pipeline)
+    assert len(target.read_rows()) == 3
+    assert len(target.read_rows()) == 3

--- a/frictionless/steps/field/field_pack.py
+++ b/frictionless/steps/field/field_pack.py
@@ -1,6 +1,7 @@
 # type: ignore
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING, Any, Iterator, List
 
 import attrs
@@ -56,7 +57,9 @@ class field_pack(Step):
             for name in self.from_names:
                 resource.schema.remove_field(name)
         processor = iterpackdict if self.as_object else iterpack  # type: ignore
-        resource.data = processor(table, self.name, self.from_names, self.preserve)
+        resource.data = partial(
+            processor, table, self.name, self.from_names, self.preserve
+        )
 
     # Metadata
 


### PR DESCRIPTION
- fixes #1476

---

`field_pack` assigned the generator returned by `iterpack`/`iterpackdict` straight to `resource.data`. A generator is exhausted after one pass, so the transformed resource returned its rows on the first `read_rows()` and zero rows on every later read (and drained the source resource with it). Assigning a `functools.partial` instead makes each read start a fresh generator — the inline parser already calls a non-iterable `data` value to get its iterator.

Added a regression test that reads the packed resource twice; it fails on `main` and passes with the fix.
