### PR TITLE
Look up namespaced SQL tables by their schema-qualified key

### DIFF
--- a/frictionless/formats/sql/__spec__/test_adapter.py
+++ b/frictionless/formats/sql/__spec__/test_adapter.py
@@ -232,6 +232,31 @@ def test_sql_adapter_package_url_argument(sqlite_url):
 # Bugs
 
 
+def test_sql_adapter_namespace_issue_1602(tmpdir):
+    # Writing to a table in a namespace (schema) raised
+    # "KeyError: '<table>'", because MetaData(schema=namespace) keys tables
+    # as "<namespace>.<name>" but the adapter looked them up by the bare name.
+    from frictionless.formats.sql import SqlControl
+    from frictionless.formats.sql.adapter import SqlAdapter
+
+    main_db = str(tmpdir.join("main.db"))
+    ns_db = str(tmpdir.join("ns.db"))
+    engine = sa.create_engine(f"sqlite:///{main_db}")
+
+    @sa.event.listens_for(engine, "connect")
+    def _attach(dbapi_conn, _record):
+        dbapi_conn.execute(f"ATTACH DATABASE '{ns_db}' AS ns")
+
+    package = Package(resources=[TableResource(path="data/table.csv")])
+    package.infer()
+
+    SqlAdapter(engine, control=SqlControl(namespace="ns")).write_package(package)
+
+    reader = SqlAdapter(engine, control=SqlControl(table="table", namespace="ns"))
+    rows = list(reader.read_cell_stream(SqlControl(table="table", namespace="ns")))
+    assert rows == [["id", "name"], [1, "english"], [2, "中国人"]]
+
+
 def test_sql_adapter_integer_enum_issue_776(sqlite_url):
     control = formats.SqlControl(table="table")
     source = TableResource(path="data/table.csv")

--- a/frictionless/formats/sql/adapter.py
+++ b/frictionless/formats/sql/adapter.py
@@ -41,11 +41,19 @@ class SqlAdapter(Adapter):
             self.metadata = sa.MetaData(schema=self.control.namespace)
             self.metadata.reflect(conn, views=True)
 
+    def _table_key(self, table_name: str) -> str:
+        # MetaData(schema=namespace) keys tables as "<namespace>.<name>",
+        # matching Table.key. Looking them up by the bare name raises
+        # KeyError whenever a namespace is set (issue #1602).
+        if self.control.namespace:
+            return f"{self.control.namespace}.{table_name}"
+        return table_name
+
     # Delete
 
     def delete_resource(self, table_name: str) -> None:
         with self.engine.begin() as conn:
-            table = self.metadata.tables[table_name]
+            table = self.metadata.tables[self._table_key(table_name)]
             self.metadata.drop_all(conn, tables=[table])
 
     # Read
@@ -62,12 +70,12 @@ class SqlAdapter(Adapter):
         return package
 
     def read_schema(self, table_name: str) -> Schema:
-        table = self.metadata.tables[table_name]
+        table = self.metadata.tables[self._table_key(table_name)]
         return self.mapper.read_schema(table, with_metadata=self.control.with_metadata)
 
     def read_cell_stream(self, control: SqlControl) -> Generator[List[Any], None, None]:
         sa = platform.sqlalchemy
-        table = self.metadata.tables[control.table]  # type: ignore
+        table = self.metadata.tables[self._table_key(control.table)]  # type: ignore
         with self.engine.begin() as conn:
             # Prepare columns
             columns = table.c
@@ -126,7 +134,7 @@ class SqlAdapter(Adapter):
     ) -> None:
         with self.engine.begin() as conn:
             if force:
-                existing_table = self.metadata.tables.get(table_name)
+                existing_table = self.metadata.tables.get(self._table_key(table_name))
                 if existing_table is not None:
                     self.metadata.drop_all(conn, tables=[existing_table])
                     self.metadata.remove(existing_table)
@@ -149,7 +157,7 @@ class SqlAdapter(Adapter):
         sa = platform.sqlalchemy
         with self.engine.begin() as conn:
             buffer: List[Dict[str, Any]] = []
-            table = self.metadata.tables[table_name]
+            table = self.metadata.tables[self._table_key(table_name)]
             for row in row_stream:
                 buffer.append(self.mapper.write_row(row))
                 if len(buffer) > settings.BUFFER_SIZE:
@@ -178,7 +186,7 @@ class SqlAdapter(Adapter):
 
             # Validate/iterate
             buffer: List[Dict[str, Any]] = []
-            table = self.metadata.tables[table_name]
+            table = self.metadata.tables[self._table_key(table_name)]
             report = resource.validate(on_row=process_row)
             if len(buffer):
                 conn.execute(sa.insert(table), buffer)


### PR DESCRIPTION
- fixes #1602

---

Writing a resource to a table inside a namespace (schema) raised `KeyError`:

```python
resource.write(sql_url, control=formats.SqlControl(table="reprex", namespace="datapackage"))
# KeyError: 'reprex'   (frictionless/formats/sql/adapter.py, write_row_stream)
```

**Cause.** `SqlAdapter.__init__` builds `MetaData(schema=self.control.namespace)`. When a schema is set, SQLAlchemy keys every table by its *schema-qualified* name — `Table.key` is `"<namespace>.<name>"`, and `metadata.tables` is keyed the same way:

```python
>>> md = sa.MetaData(schema="ns")
>>> t = sa.Table("reprex", md, sa.Column("x", sa.Integer))
>>> list(md.tables)        # ['ns.reprex']
>>> t.key                  # 'ns.reprex'
>>> md.tables["reprex"]    # KeyError
```

But every lookup in the adapter used the **bare** name — `self.metadata.tables[table_name]` — so `write_row_stream`, `read_schema`, `read_cell_stream`, `delete_resource` and `write_resource_with_metadata` all `KeyError` the moment a namespace is in play.

**Fix.** Route the six lookups through a small helper that prepends the namespace when one is configured, matching how the tables are actually keyed:

```python
def _table_key(self, table_name: str) -> str:
    if self.control.namespace:
        return f"{self.control.namespace}.{table_name}"
    return table_name
```

No behaviour changes when `namespace` is `None` (the helper returns the name unchanged), so the existing non-namespaced paths are untouched.

### Verification

Reproduced and fixed end-to-end on SQLite with an attached schema (no server needed):

```
without fix:  KeyError: 'table'   at adapter.py write_row_stream
with fix:     wrote + read back -> [['id','name'], [1,'english'], [2,'中国人']]
```

Added `test_sql_adapter_namespace_issue_1602` in the adapter spec's Bugs section — it attaches a second SQLite database as a schema, writes a package into it, and reads the rows back. Reverting only `adapter.py` while keeping the test makes it fail with the original `KeyError`, so it guards the fix. The full SQL adapter suite is **38 passed / 0 failed** (59 skipped are the server-backed backends). `ruff format --check` is clean, and `ruff check` reports the same count on `adapter.py` before and after, so this adds no new lint.
