### PR TITLE
fix(ci): pin version of ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
 dev = [
     "moto",
     # 0.16 greatly expands the default rule set
-    "ruff>=0.15,<0.16",
+    "ruff<0.16",
     "httpx",
     "hatch",
     "yattag",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "moto",
-    "ruff",
+    # 0.16 greatly expands the default rule set
+    "ruff>=0.15,<0.16",
     "httpx",
     "hatch",
     "yattag",


### PR DESCRIPTION
Ruff v0.16 introduces a lot of new default checks, breaking the CI.

When we upgrade to ruff 0.16, we'll need to determine which checks are relevant to the project and update the code accordingly. For now, I'm pinning the version. 
