### PR TITLE
fix: raise when ignoring case creates ambiguous fields

### DIFF
--- a/frictionless/resource/__spec__/test_validate_schema.py
+++ b/frictionless/resource/__spec__/test_validate_schema.py
@@ -333,6 +333,34 @@ def test_resource_validate_duplicate_labels_ignoring_header_case():
     ]
 
 
+def test_resource_validate_fields_only_distinguished_by_case_are_rejected():
+    # The schema is valid: "a" and "A" are distinct field names. But with
+    # `header_case` off they collapse onto the same key.
+    schema = Schema.from_descriptor(
+        {
+            "fields": [
+                {"name": "a", "type": "string"},
+                {"name": "A", "type": "integer"},
+            ],
+            "fieldsMatch": "partial",
+        }
+    )
+    resource = TableResource(
+        [["A"], ["x"]],
+        schema=schema,
+        dialect=Dialect(header_case=False),
+    )
+    report = resource.validate()
+    assert report.flatten(["type", "note"]) == [
+        [
+            "metadata-error",
+            'matching fields by name ("fieldsMatch": "partial") is ambiguous: '
+            'fields "a", "A" differ only by case, which "header_case" is set '
+            "to ignore",
+        ],
+    ]
+
+
 def test_resource_validate_less_actual_fields_with_required_constraint_issue_950():
     schema = Schema.describe("data/table.csv")
     schema.add_field(fields.AnyField(name="bad", constraints={"required": True}))

--- a/frictionless/table/__spec__/test_header.py
+++ b/frictionless/table/__spec__/test_header.py
@@ -153,6 +153,35 @@ def test_get_expected_fields_raises_on_duplicate_labels(fields_match):
         header.get_expected_fields()
 
 
+@pytest.mark.parametrize("fields_match", NAME_MATCHED)
+def test_get_expected_fields_raises_on_fields_colliding_under_ignore_case(fields_match):
+    header = _make_header(["a"], ["a", "A"], fields_match=fields_match, ignore_case=True)
+    with pytest.raises(frictionless.FrictionlessException) as excinfo:
+        header.get_expected_fields()
+    assert excinfo.value.error.type == "metadata-error"
+
+
+def test_get_expected_fields_colliding_fields_error_names_the_culprits():
+    header = _make_header(["a"], ["a", "A"], fields_match="partial", ignore_case=True)
+    with pytest.raises(frictionless.FrictionlessException) as excinfo:
+        header.get_expected_fields()
+    note = excinfo.value.error.note
+    assert "header_case" in note
+    assert '"a"' in note and '"A"' in note
+
+
+def test_get_expected_fields_exact_tolerates_fields_colliding_under_ignore_case():
+    # Mapping is positional, so the fields are never told apart by name.
+    header = _make_header(["a", "A"], ["a", "A"], fields_match="exact", ignore_case=True)
+    assert [f.name for f in header.get_expected_fields()] == ["a", "A"]
+
+
+def test_get_expected_fields_tolerates_case_distinct_fields_when_case_matters():
+    # Without `ignore_case`, `a` and `A` are simply two distinct fields.
+    header = _make_header(["a", "A"], ["a", "A"], fields_match="partial")
+    assert [f.name for f in header.get_expected_fields()] == ["a", "A"]
+
+
 def test_get_expected_fields_exact_tolerates_duplicate_labels():
     # Mapping is positional, so duplicates are unambiguous here; they are
     # reported as a `duplicate-label` error rather than raising.

--- a/frictionless/table/header.py
+++ b/frictionless/table/header.py
@@ -155,6 +155,17 @@ class Header(List[str]):  # type: ignore
             self.__expected_fields = self.__fields
             return self.__expected_fields
 
+        # ignore_case can make fields ambiguous as their keys are identical,
+        # e.g. "A" and "a"
+        for group in self.__matching.ambiguous_fields:
+            names = ", ".join(f'"{field.name}"' for field in group)
+            note = (
+                f'matching fields by name ("fieldsMatch": "{self.__fields_match}") '
+                f"is ambiguous: fields {names} differ only by case, which "
+                '"header_case" is set to ignore'
+            )
+            raise FrictionlessException(errors.MetadataError(note=note))
+
         if self.__matching.has_duplicate_labels:
             note = (
                 f'matching fields by name ("fieldsMatch": "{self.__fields_match}") '

--- a/frictionless/table/label_matching.py
+++ b/frictionless/table/label_matching.py
@@ -49,6 +49,20 @@ class LabelMatching:
         ]
 
     @property
+    def ambiguous_fields(self) -> List[List[Field]]:
+        """Groups of fields that normalization merges into a single key
+
+        Fields sharing the very same name make the schema itself invalid, which is caught
+        before a header is ever built.
+        """
+        groups: Dict[str, List[Field]] = {}
+        for field in self.__fields:
+            groups.setdefault(self.__normalize(field.name), []).append(field)
+        return [
+            group for group in groups.values() if len({field.name for field in group}) > 1
+        ]
+
+    @property
     def has_duplicate_labels(self) -> bool:
         """Whether two labels match the same field, which makes the mapping ambiguous
 


### PR DESCRIPTION
# Context 

follow-up to #1797, which handles duplicate labels when ignoring case. 
This PR handles ambiguous fields under "ignore-case=True", which were silently ignored during validation. 

# Fix 

Ambiguous fields under "ignore-case" raise now an error : there is no obvious default behavior and the schema schould *not* be used with "ignore-case=True" in this circumstances.
