### PR TITLE
Keep multipart CSV rows intact when a part lacks a trailing newline

### DIFF
--- a/frictionless/schemes/multipart/__spec__/test_loader.py
+++ b/frictionless/schemes/multipart/__spec__/test_loader.py
@@ -3,8 +3,8 @@ import sys
 
 import pytest
 
-from frictionless import FrictionlessException, platform, schemes
-from frictionless.resources import TableResource
+from frictionless import Dialect, FrictionlessException, platform, schemes
+from frictionless.resources import FileResource, TableResource
 
 BASEURL = "https://raw.githubusercontent.com/frictionlessdata/frictionless-py/master/%s"
 
@@ -175,3 +175,48 @@ def test_multipart_loader_with_compressed_parts_issue_1215():
             {"id": 1, "name": "english"},
             {"id": 2, "name": "中国人"},
         ]
+
+
+def test_multipart_loader_part_without_trailing_newline_issue_1778(tmpdir):
+    # The last row of a part without a trailing newline was glued onto the
+    # first row of the next part ({"id": 1, "name": "english2"}).
+    path1 = str(tmpdir.join("chunk1.csv"))
+    path2 = str(tmpdir.join("chunk2.csv"))
+    with open(path1, "wb") as file:
+        file.write(b"id,name\n1,english")
+    with open(path2, "wb") as file:
+        file.write(b"id,name\n2,german\n")
+    with TableResource(path=path1, extrapaths=[path2]) as resource:
+        assert resource.read_rows() == [
+            {"id": 1, "name": "english"},
+            {"id": 2, "name": "german"},
+        ]
+
+
+def test_multipart_loader_headless_part_without_trailing_newline_issue_1778(tmpdir):
+    path1 = str(tmpdir.join("chunk1.csv"))
+    path2 = str(tmpdir.join("chunk2.csv"))
+    with open(path1, "wb") as file:
+        file.write(b"1,english")
+    with open(path2, "wb") as file:
+        file.write(b"2,german\n")
+    resource = TableResource(
+        path=path1, extrapaths=[path2], dialect=Dialect(header=False)
+    )
+    with resource:
+        assert resource.read_rows() == [
+            {"field1": 1, "field2": "english"},
+            {"field1": 2, "field2": "german"},
+        ]
+
+
+def test_multipart_loader_binary_parts_stay_verbatim_issue_1778(tmpdir):
+    # Non-tabular parts are chunks of one file: no newline may be inserted.
+    path1 = str(tmpdir.join("part1.bin"))
+    path2 = str(tmpdir.join("part2.bin"))
+    with open(path1, "wb") as file:
+        file.write(b"\x00\x01NOEOL")
+    with open(path2, "wb") as file:
+        file.write(b"\x02\x03\n")
+    with FileResource(path=path1, extrapaths=[path2]) as resource:
+        assert resource.read_file() == b"\x00\x01NOEOL\x02\x03\n"

--- a/frictionless/schemes/multipart/loader.py
+++ b/frictionless/schemes/multipart/loader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import tempfile
-from typing import Any, List
+from typing import Any
 
 from ... import helpers, types
 from ...resources import FileResource
@@ -21,12 +21,14 @@ class MultipartLoader(Loader):
     def read_byte_stream_create(self):  # type: ignore
         assert self.resource.normpath
         remote = self.resource.remote
+        tabular = self.resource.format == "csv"
         headless = self.resource.dialect.header is False
-        headless = headless or self.resource.format != "csv"
+        headless = headless or not tabular
         return MultipartByteStream(
             self.resource.normpaths,
             remote=remote,
             headless=headless,
+            tabular=tabular,
         )
 
     # Write
@@ -50,10 +52,11 @@ class MultipartLoader(Loader):
 
 
 class MultipartByteStream:
-    def __init__(self, paths: List[str], *, remote: bool, headless: bool):
+    def __init__(self, paths: list[str], *, remote: bool, headless: bool, tabular: bool):
         self.__paths = paths
         self.__remote = remote
         self.__headless = headless
+        self.__tabular = tabular
         self.__line_stream = self.read_line_stream()
 
     def __enter__(self):
@@ -105,8 +108,22 @@ class MultipartByteStream:
 
     def read_line_stream(self):
         for number, path in enumerate(self.__paths, start=1):
+            last_line = None
             with FileResource(path=path) as resource:
                 for line_number, line in enumerate(resource.byte_stream, start=1):
                     if not self.__headless and number > 1 and line_number == 1:
                         continue
-                    yield line
+                    if last_line is not None:
+                        yield last_line
+                    last_line = line
+            if last_line is not None:
+                # A tabular part that does not end with a newline would glue its
+                # last row onto the first row of the next part. Binary parts are
+                # concatenated verbatim: they are chunks of one file.
+                if (
+                    self.__tabular
+                    and number < len(self.__paths)
+                    and not last_line.endswith(b"\n")
+                ):
+                    last_line += b"\n"
+                yield last_line


### PR DESCRIPTION
Closes #1778.

The multipart byte stream concatenates the parts line by line, so a CSV part whose last line has no trailing newline glued that row onto the first data row of the next part — `chunk1.csv` = `id,name\n1,english` plus `chunk2.csv` = `id,name\n2,german\n` produced the single corrupted row `{"id": 1, "name": "english2"}` instead of two rows. The same happens for headless multipart CSVs.

The fix appends the missing newline to the last line of a CSV part when another part follows. Two deliberate boundaries:

- **Non-tabular parts are untouched.** For any other format the parts are chunks of one file (the loader's existing `format != "csv"` distinction), and inserting bytes would corrupt the reassembled file. A regression test pins this: `b"\x00\x01NOEOL"` + `b"\x02\x03\n"` still reassembles verbatim.
- **The final part is left as-is** — with no following part there is nothing to glue, so the stream stays byte-faithful there too.

Three tests added (header CSV, headless CSV, binary verbatim); the two CSV tests fail on `main` and pass with the fix. The full multipart scheme suite passes (8 passed, 4 skipped — the skips are the pre-existing remote/vcr ones). Also verified with CRLF endings and a three-part resource whose middle part lacks the newline.

While touching the constructor I switched its `List[str]` annotation to `list[str]` — ruff's UP006 flags the line once edited; the file's other pre-existing findings are left alone.