### PR TITLE
Add --jsonschema option to the validate CLI command

### DIFF
--- a/data/jsonschema.json
+++ b/data/jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "id": { "type": "integer" },
+    "name": { "type": "string" }
+  },
+  "required": ["id", "name"]
+}

--- a/frictionless/console/commands/__spec__/test_validate.py
+++ b/frictionless/console/commands/__spec__/test_validate.py
@@ -3,7 +3,7 @@ import json
 import pytest
 import yaml
 
-from frictionless import Detector, Dialect, validate
+from frictionless import Detector, Dialect, Schema, validate
 from frictionless.console import console
 
 from .conftest import create_runner
@@ -66,6 +66,19 @@ def test_console_validate_field_names():
     actual = runner.invoke(console, "validate data/table.csv --json --field-names 'a,b'")
     expect = validate("data/table.csv", detector=Detector(field_names=["a", "b"]))
     assert actual.exit_code == 1
+    assert no_time(json.loads(actual.stdout)) == no_time(expect.to_descriptor())
+
+
+def test_console_validate_jsonschema_1500():
+    actual = runner.invoke(
+        console,
+        "validate data/table.csv --json --jsonschema data/jsonschema.json",
+    )
+    expect = validate(
+        "data/table.csv",
+        schema=Schema.from_jsonschema("data/jsonschema.json"),
+    )
+    assert actual.exit_code == 0
     assert no_time(json.loads(actual.stdout)) == no_time(expect.to_descriptor())
 
 

--- a/frictionless/console/commands/validate.py
+++ b/frictionless/console/commands/validate.py
@@ -6,6 +6,7 @@ import typer
 from rich.table import Table
 
 from ...resource import Resource
+from ...schema import Schema
 from ...system import system
 from .. import common, helpers
 from ..console import console
@@ -25,6 +26,7 @@ def console_validate(
     innerpath: str = common.innerpath,
     compression: str = common.compression,
     schema: str = common.schema,
+    jsonschema: str = common.jsonschema,
     hash: str = common.hash,
     bytes: int = common.bytes,
     fields: int = common.fields,
@@ -121,6 +123,9 @@ def console_validate(
             skip_errors=skip_errors,
         )
 
+        # Create schema
+        schema_obj = Schema.from_jsonschema(jsonschema) if jsonschema else schema
+
         # Create resource
         resource = Resource(
             source=helpers.create_source(source),
@@ -136,7 +141,7 @@ def console_validate(
             bytes=bytes,
             fields=fields,
             rows=rows,
-            schema=schema,
+            schema=schema_obj,
             basepath=basepath,
             detector=detector_obj,
         )

--- a/frictionless/console/common.py
+++ b/frictionless/console/common.py
@@ -126,6 +126,11 @@ schema = Option(
     help="Specify a path to a schema",
 )
 
+jsonschema = Option(
+    default=None,
+    help="Specify a path to a JSON Schema profile (converted to a Table Schema)",
+)
+
 # Checklist
 
 checklist = Option(


### PR DESCRIPTION
## Change Description

Fixes #1500. As noted in the issue by @roll:

> It's not supported yet but I think it's a good idea something like:
> ```
> frictionless validate table.csv --jsonschema <schema>
> ```
> The mapper is already implemented so it will be a simple feature to add

This adds exactly that: a `--jsonschema` option on the `validate` console command that takes a path to a JSON Schema profile, runs it through the existing `Schema.from_jsonschema()` mapper, and uses the resulting Table Schema to validate the resource — mirroring how `--schema` already works, just with a JSON Schema source instead.

## Testing/Review Recommendations

- Installed the package locally (editable install) and ran it end-to-end:
  - `frictionless validate table.csv --jsonschema schema.json` against a JSON Schema requiring an integer `id`, with one row containing a non-numeric `id` — correctly reported `INVALID` with a `type-error` on the right row/field, exit code 1.
  - Same file with all-valid rows — `VALID`, exit code 0.
  - Confirmed no regression on the existing no-schema and `--schema-sync` paths.
- Ran the full existing `frictionless/console/commands/__spec__/test_validate.py` suite: 25 passed, 4 skipped (pre-existing skips, unrelated) before my change; 26 passed, 4 skipped after adding `test_console_validate_jsonschema_1500`, which follows this file's existing pattern (compares CLI JSON output against calling `validate()` directly with the equivalent Python API).
- `ruff format --check` and `ruff check` pass on all changed files.
- Added `data/jsonschema.json` as a small fixture (matching `data/table.csv`'s `id`/`name` columns) since the existing `data/ecrin.json` JSON Schema fixture requires a `display_title` field that doesn't apply here.
