### PR TITLE
fix(excel): report missing frictionless[excel] instead of invalid excel file

### DIFF
--- a/frictionless/formats/excel/parsers/__spec__/test_xlsx.py
+++ b/frictionless/formats/excel/parsers/__spec__/test_xlsx.py
@@ -67,6 +67,16 @@ def test_xlsx_parser_format_error_sheet_by_index_not_existent():
     assert error.note == 'Excel document "data/sheet2.xlsx" does not have a sheet "3"'
 
 
+def test_xlsx_parser_missing_extra_dependency(monkeypatch: pytest.MonkeyPatch):
+    # https://github.com/frictionlessdata/frictionless-py/issues/1756
+    monkeypatch.setitem(sys.modules, "openpyxl", None)
+    monkeypatch.delitem(platform.__dict__, "openpyxl", raising=False)
+    resource = TableResource(path="data/table.xlsx")
+    with pytest.raises(FrictionlessException) as excinfo:
+        resource.open()
+    assert excinfo.value.error.note == 'Please install "frictionless[excel]"'
+
+
 def test_xlsx_parser_sheet_by_name():
     path = "data/sheet2.xlsx"
     control = formats.ExcelControl(sheet="Sheet2")

--- a/frictionless/formats/excel/parsers/xlsx.py
+++ b/frictionless/formats/excel/parsers/xlsx.py
@@ -79,9 +79,12 @@ class XlsxParser(Parser):
         # Get book
         # To fill merged cells we can't use read-only because
         # `sheet.merged_cell_ranges` is not available in this mode
+        # NOTE: resolve the dependency outside the try/except so that a missing
+        # `frictionless[excel]` install is not reported as an invalid excel file
+        openpyxl = platform.openpyxl
         try:
             warnings.filterwarnings("ignore", category=UserWarning, module="openpyxl")
-            book = platform.openpyxl.load_workbook(
+            book = openpyxl.load_workbook(
                 self.loader.byte_stream,
                 read_only=not control.fill_merged_cells,
                 data_only=True,


### PR DESCRIPTION
- fixes #1756

---

The xlsx parser resolved `platform.openpyxl` inside the `try/except` around `load_workbook`, so when `frictionless[excel]` is not installed the `@extras` install hint was swallowed and re-raised as `invalid excel file "table.xlsx"`. Resolving the attribute before the `try` block lets the hint propagate while genuine parse failures still map to a format error.

The regression test forces the import to fail via `sys.modules`, so it exercises the missing-dependency path even in CI where openpyxl is installed; it fails on the unpatched parser with the `invalid excel file` note and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
