### PR TITLE
refactor: align label normalization between detection and header matching

### DIFF
--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -331,7 +331,6 @@ class Detector:
 
             # Prepare names
             names = copy(self.field_names or labels or [])
-            names = list(map(lambda cell: cell.replace("\n", " ").strip(), names))
             if not names:
                 if not fragment:
                     return schema

--- a/frictionless/table/header.py
+++ b/frictionless/table/header.py
@@ -53,7 +53,6 @@ class Header(List[str]):  # type: ignore
             self.__fields.append(copy)
         self.__field_names = self.copy()
         self.__row_numbers = row_numbers
-        self.__ignore_case = ignore_case
         self.__fields_match = fields_match
         self.__labels = labels
         self.__errors: List[errors.HeaderError] = []
@@ -376,10 +375,7 @@ class Header(List[str]):  # type: ignore
 
             # Incorrect Label
             if label:
-                name = field.name
-                # NOTE: review where we normalize the label/name
-                lname = label.replace("\n", " ").strip()
-                if name.lower() != lname.lower() if self.__ignore_case else name != lname:
+                if not self.__matching.matches(label, field):
                     self.__errors.append(
                         errors.IncorrectLabelError(
                             note="",

--- a/frictionless/table/label_matching.py
+++ b/frictionless/table/label_matching.py
@@ -38,6 +38,15 @@ class LabelMatching:
         """Returns the field the given label matches, or None if there is none"""
         return self.__fields_by_key.get(self.__normalize(label))
 
+    def matches(self, label: str, field: Field) -> bool:
+        """Whether the given label and field designate the same column
+
+        Unlike `matching_field`, which searches the whole schema, this answers
+        for one given pair -- what the positional modes need, since there the
+        pairing comes from the order rather than from the names.
+        """
+        return self.__normalize(label) == self.__normalize(field.name)
+
     @property
     def unmatched_fields(self) -> List[Field]:
         """The fields no label matches, in schema order"""


### PR DESCRIPTION
The LabelMatching class now deals with normalization in a single place (previously spread between Detector and Header).

This PR introduces a small change in behavior, which I consider a fix rather than a breaking change as this behavior was unspecified and untested : newlines were considered as special characters and were replaced with whitespace, so that "a\nb"   would match "a b". 