### PR TITLE
refactor: factorize label deduplication logic

### DIFF
--- a/frictionless/detector/__spec__/test_general.py
+++ b/frictionless/detector/__spec__/test_general.py
@@ -91,6 +91,14 @@ def test_schema_infer_no_names():
     }
 
 
+def test_schema_from_sample_deduplicate_names_avoids_collision():
+    labels = ["a", "a2", "a"]
+    sample = [["1", "2", "3"]]
+    detector = Detector()
+    schema = detector.detect_schema(sample, labels=labels)
+    assert schema.field_names == ["a", "a2", "a3"]
+
+
 def test_detector_set_buffer_size():
     detector = Detector(buffer_size=10)
     assert detector.buffer_size == 10

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import codecs
 import os
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
 import attrs
 
@@ -342,12 +342,16 @@ class Detector:
 
             # Deduplicate names
             if len(names) != len(set(names)):
-                seen_names: List[str] = []
+                used_names: Set[str] = set()
                 names = names.copy()
                 for index, name in enumerate(names):
-                    count = seen_names.count(name) + 1
-                    names[index] = "%s%s" % (name, count) if count > 1 else name
-                    seen_names.append(name)
+                    new_name = name
+                    suffix = 2
+                    while new_name in used_names:
+                        new_name = f"{name}{suffix}"
+                        suffix += 1
+                    names[index] = new_name
+                    used_names.add(new_name)
 
             # Handle type/empty
             if self.field_type or not fragment:

--- a/frictionless/detector/detector.py
+++ b/frictionless/detector/detector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import codecs
 import os
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import attrs
 
@@ -13,6 +13,7 @@ from ..fields import AnyField
 from ..metadata import Metadata
 from ..platform import platform
 from ..schema import Field, Schema
+from ..table.label_matching import deduplicate_names
 
 if TYPE_CHECKING:
     from .. import types
@@ -341,17 +342,7 @@ class Detector:
                 names[index] = name or f"field{index + 1}"
 
             # Deduplicate names
-            if len(names) != len(set(names)):
-                used_names: Set[str] = set()
-                names = names.copy()
-                for index, name in enumerate(names):
-                    new_name = name
-                    suffix = 2
-                    while new_name in used_names:
-                        new_name = f"{name}{suffix}"
-                        suffix += 1
-                    names[index] = new_name
-                    used_names.add(new_name)
+            names = deduplicate_names(names)
 
             # Handle type/empty
             if self.field_type or not fragment:

--- a/frictionless/schema/schema.py
+++ b/frictionless/schema/schema.py
@@ -180,15 +180,6 @@ class Schema(Metadata, metaclass=Factory):
         """Remove all the fields"""
         self.fields = []
 
-    def deduplicate_fields(self):
-        if len(self.field_names) != len(set(self.field_names)):
-            seen_names: List[str] = []
-            for index, name in enumerate(self.field_names):
-                count = seen_names.count(name) + 1
-                if count > 1:
-                    self.fields[index].name = "%s%s" % (name, count)
-                seen_names.append(name)
-
     # Describe
 
     @staticmethod

--- a/frictionless/table/header.py
+++ b/frictionless/table/header.py
@@ -57,7 +57,12 @@ class Header(List[str]):  # type: ignore
         self.__labels = labels
         self.__errors: List[errors.HeaderError] = []
         self.__expected_fields: Optional[List[Field]] = None
-        self.__matching = LabelMatching(labels, self.__fields, ignore_case=ignore_case)
+        self.__matching = LabelMatching(
+            labels,
+            self.__fields,
+            ignore_case=ignore_case,
+            by_name=self.__matches_by_name,
+        )
         self.__process()
 
     @cached_property
@@ -139,14 +144,15 @@ class Header(List[str]):  # type: ignore
     def get_expected_fields(self) -> List[Field]:
         """Returns the fields, in the order expected in the data.
 
-        Under `exact`, schema fields keep their order and are truncated or
-        extended with `any`-typed fields to match the labels.
+        Each label gets the field it pairs with (by position when
+        `fieldsMatch` is `"exact"`, by name otherwise), a label
+        with no field gets an artificial `any`-typed
+        field named after it (so that it is reported once rather than once per
+        row), and fields no label pairs with are dropped.
 
-        Under the name-matched modes, fields are reordered to match the labels;
-        labels without a matching field get a fresh `any`-typed field (even
-        where such a label is an error, so that it is reported once rather than
-        once per row), and fields not present in labels are dropped. Duplicate
-        labels are rejected, as they make the mapping ambiguous.
+        Under the name-matched modes, duplicate labels are rejected, as they make
+        the pairing ambiguous. Under `exact`, fabricated `any`-typed field
+        names are deduplicated.
         """
         if self.__expected_fields is not None:
             return self.__expected_fields
@@ -155,81 +161,72 @@ class Header(List[str]):  # type: ignore
             self.__expected_fields = self.__fields
             return self.__expected_fields
 
-        if not self.__matches_by_name:
-            expected = self.__fields[: len(self.__labels)]
-            extra_labels = self.__labels[len(expected) :]
-            # The schema field names come first, so deduplication only ever
-            # renames the fabricated ones
-            names = deduplicate_names([field.name for field in expected] + extra_labels)
-            for name in names[len(expected) :]:
-                expected.append(Field.from_descriptor({"name": name, "type": "any"}))
+        if self.__matches_by_name:
+            # ignore_case can make fields ambiguous as their keys are identical,
+            # e.g. "A" and "a"
+            for group in self.__matching.ambiguous_fields:
+                names = ", ".join(f'"{field.name}"' for field in group)
+                note = (
+                    f'matching fields by name ("fieldsMatch": "{self.__fields_match}") '
+                    f"is ambiguous: fields {names} differ only by case, which "
+                    '"header_case" is set to ignore'
+                )
+                raise FrictionlessException(errors.MetadataError(note=note))
 
-            self.__expected_fields = expected
-            return self.__expected_fields
+            if self.__matching.has_duplicate_labels:
+                note = (
+                    f'matching fields by name ("fieldsMatch": "{self.__fields_match}") '
+                    "requires unique labels in the header"
+                )
+                raise FrictionlessException(note)
 
-        # ignore_case can make fields ambiguous as their keys are identical,
-        # e.g. "A" and "a"
-        for group in self.__matching.ambiguous_fields:
-            names = ", ".join(f'"{field.name}"' for field in group)
-            note = (
-                f'matching fields by name ("fieldsMatch": "{self.__fields_match}") '
-                f"is ambiguous: fields {names} differ only by case, which "
-                '"header_case" is set to ignore'
+        matched = [
+            self.__matching.matching_field(position, label)
+            for position, label in enumerate(self.__labels)
+        ]
+
+        # A fabricated field is named after its label, deduplicated if needed.
+        # Matched fields are already unique and come first, so deduplication will only rename
+        # fabricated fields.
+        names = deduplicate_names(
+            [
+                field.name if field is not None else label
+                for field, label in zip(matched, self.__labels)
+            ]
+        )
+        self.__expected_fields = [
+            (
+                field
+                if field is not None
+                else Field.from_descriptor({"name": name, "type": "any"})
             )
-            raise FrictionlessException(errors.MetadataError(note=note))
-
-        if self.__matching.has_duplicate_labels:
-            note = (
-                f'matching fields by name ("fieldsMatch": "{self.__fields_match}") '
-                "requires unique labels in the header"
-            )
-            raise FrictionlessException(note)
-
-        expected: List[Field] = []
-        for label in self.__labels:
-            field = self.__matching.matching_field(label)
-            if field is None:
-                field = Field.from_descriptor({"name": label, "type": "any"})
-            expected.append(field)
-        self.__expected_fields = expected
+            for field, name in zip(matched, names)
+        ]
         return self.__expected_fields
 
     def _get_extra_labels(self) -> List[Tuple[int, str]]:
         """Returns (field_number, label) pairs for labels in the data that
-        don't correspond to any schema field.
-
-        Under `exact`, the extras are the labels beyond the schema's field
-        count. Under name matching, an extra label is one whose name matches no
-        field.
+        pair with no schema field: the labels beyond the schema's field count
+        under `exact`, the labels whose name matches no field under name
+        matching.
 
         `subset` and `partial` accept extra labels, so they report none.
         """
-        labels = self.__labels
-
-        if not self.__matches_by_name:
-            return [
-                (number, label)
-                for number, label in enumerate(labels, start=1)
-                if number > len(self.__fields)
-            ]
-
         if self.__fields_match in TOLERATES_EXTRA_LABELS:
             return []
 
         return [
             (number, label)
-            for number, label in enumerate(labels, start=1)
-            if self.__matching.matching_field(label) is None
+            for number, label in enumerate(self.__labels, start=1)
+            if self.__matching.matching_field(number - 1, label) is None
         ]
 
     def _get_missing_fields(self) -> List[Tuple[int, Field]]:
-        """Returns (field_number, field) pairs for schema fields that don't
-        have a corresponding label.
-
-        Under `exact`, the missing fields are those beyond the labels count.
-        Under name matching, they are the fields whose name is not among the
-        labels — restricted to the required ones for `superset` and `partial`,
-        which otherwise accept a data source with fewer fields.
+        """Returns (field_number, field) pairs for schema fields that pair
+        with no label: the fields beyond the labels count when `fieldsMatch`
+        is `"exact"`, the fields whose name is not among the labels under name matching —
+        restricted to the required ones for `superset` and `partial`, which
+        otherwise accept a data source with fewer fields.
 
         The field_number is `len(labels) + offset + 1` in every mode: under
         `exact` the missing fields are precisely the tail of the schema, so
@@ -237,23 +234,17 @@ class Header(List[str]):  # type: ignore
         have no natural position in the data, so we place them after the
         labels by convention.
         """
-        fields = self.__fields
-        labels = self.__labels
 
-        if not self.__matches_by_name:
-            missing = fields[len(labels) :] if len(fields) > len(labels) else []
-        else:
+        def is_required(field: Field) -> bool:
+            return field.required or (
+                field.schema is not None and field.name in field.schema.primary_key
+            )
 
-            def is_required(field: Field) -> bool:
-                return field.required or (
-                    field.schema is not None and field.name in field.schema.primary_key
-                )
+        missing = self.__matching.unmatched_fields
+        if self.__fields_match in TOLERATES_MISSING_FIELDS:
+            missing = [field for field in missing if is_required(field)]
 
-            missing = self.__matching.unmatched_fields
-            if self.__fields_match in TOLERATES_MISSING_FIELDS:
-                missing = [field for field in missing if is_required(field)]
-
-        start = len(labels) + 1
+        start = len(self.__labels) + 1
         return [(start + offset, field) for offset, field in enumerate(missing)]
 
     # Convert

--- a/frictionless/table/header.py
+++ b/frictionless/table/header.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 from .. import errors, helpers, types
 from ..exception import FrictionlessException
 from ..schema import Field
-from .label_matching import LabelMatching
+from .label_matching import LabelMatching, deduplicate_names
 
 # The `fieldsMatch` modes are told apart by which mismatch they tolerate: a
 # label with no matching field, or a declared field with no matching label
@@ -157,17 +157,11 @@ class Header(List[str]):  # type: ignore
 
         if not self.__matches_by_name:
             expected = self.__fields[: len(self.__labels)]
-            used_names = {field.name for field in expected}
-
-            for label in self.__labels[len(expected) :]:
-                name = label
-                suffix = 2
-
-                while name in used_names:
-                    name = f"{label}{suffix}"
-                    suffix += 1
-
-                used_names.add(name)
+            extra_labels = self.__labels[len(expected) :]
+            # The schema field names come first, so deduplication only ever
+            # renames the fabricated ones
+            names = deduplicate_names([field.name for field in expected] + extra_labels)
+            for name in names[len(expected) :]:
                 expected.append(Field.from_descriptor({"name": name, "type": "any"}))
 
             self.__expected_fields = expected

--- a/frictionless/table/label_matching.py
+++ b/frictionless/table/label_matching.py
@@ -1,8 +1,29 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from ..schema import Field
+
+
+def deduplicate_names(names: List[str]) -> List[str]:
+    """Renames the duplicated names so that every name is unique.
+
+    The first occurrence keeps its name; a later duplicate becomes the first
+    free name among `{name}2`, `{name}3`, etc. Names are compared
+    case-sensitively, matching the schema validity rule (fields differing
+    only by case are distinct).
+    """
+    result: List[str] = []
+    used_names: Set[str] = set()
+    for name in names:
+        new_name = name
+        suffix = 2
+        while new_name in used_names:
+            new_name = f"{name}{suffix}"
+            suffix += 1
+        result.append(new_name)
+        used_names.add(new_name)
+    return result
 
 
 class LabelMatching:

--- a/frictionless/table/label_matching.py
+++ b/frictionless/table/label_matching.py
@@ -27,12 +27,16 @@ def deduplicate_names(names: List[str]) -> List[str]:
 
 
 class LabelMatching:
-    """Pairs the labels read from the data source with the schema fields, by name.
+    """Pairs the labels read from the data source with the schema fields.
+
+    Labels and fields are paired by name or, when `by_name` is false, by
+    their position -- how the `exact` fieldsMatch mode expects them to match.
 
     Parameters:
         labels (str[]): the header row as read from the data source
         fields (Field[]): the fields declared in the schema, in schema order
         ignore_case (bool): compare labels and field names case-insensitively
+        by_name (bool): pair labels and fields by name rather than by position
     """
 
     def __init__(
@@ -41,10 +45,12 @@ class LabelMatching:
         fields: List[Field],
         *,
         ignore_case: bool = False,
+        by_name: bool = True,
     ) -> None:
         self.__labels = labels
         self.__fields = fields
         self.__ignore_case = ignore_case
+        self.__by_name = by_name
 
         # Keyed by normalized name, in schema order; the first field wins in
         # case of duplicates under normalization, so the duplicate fields are
@@ -55,8 +61,15 @@ class LabelMatching:
 
         self.__fields_by_key = fields_by_key
 
-    def matching_field(self, label: str) -> Optional[Field]:
-        """Returns the field the given label matches, or None if there is none"""
+    def matching_field(self, position: int, label: str) -> Optional[Field]:
+        """Returns the field the label at the given position pairs with, or None
+
+        Parameters:
+            position (int): 0-based position of the label in the header
+            label (str): the label itself
+        """
+        if not self.__by_name:
+            return self.__fields[position] if position < len(self.__fields) else None
         return self.__fields_by_key.get(self.__normalize(label))
 
     def matches(self, label: str, field: Field) -> bool:
@@ -70,7 +83,9 @@ class LabelMatching:
 
     @property
     def unmatched_fields(self) -> List[Field]:
-        """The fields no label matches, in schema order"""
+        """The fields no label pairs with, in schema order"""
+        if not self.__by_name:
+            return self.__fields[len(self.__labels) :]
         matched = {self.__normalize(label) for label in self.__labels}
         return [
             field
@@ -104,8 +119,11 @@ class LabelMatching:
 
     @property
     def has_match(self) -> bool:
-        """Whether at least one label matches a schema field"""
-        return any(self.matching_field(label) is not None for label in self.__labels)
+        """Whether at least one label pairs with a schema field"""
+        return any(
+            self.matching_field(position, label) is not None
+            for position, label in enumerate(self.__labels)
+        )
 
     def __normalize(self, name: str) -> str:
         """The normalized value a label and a field name are compared through"""

--- a/frictionless/table/label_matching.py
+++ b/frictionless/table/label_matching.py
@@ -29,8 +29,8 @@ def deduplicate_names(names: List[str]) -> List[str]:
 class LabelMatching:
     """Pairs the labels read from the data source with the schema fields.
 
-    Labels and fields are paired by name or, when `by_name` is false, by
-    their position -- how the `exact` fieldsMatch mode expects them to match.
+    Labels and fields are paired by name when `by_name` is true, by
+    their position otherwise.
 
     Parameters:
         labels (str[]): the header row as read from the data source


### PR DESCRIPTION
This PR factorizes the deduplication logic (a similar logic was at three places, with one never used), and align the code between matching by position and by name inside the LabelMatcher class.  

It introduces a minor breaking change by removing the method `Schema.deduplicate_fields`, which is undocumented, untested, and was never used inside the codebase.