### PR TITLE
Revert fix: remove side effects from row.__str__ and row.__repr__

### DIFF
--- a/frictionless/table/row.py
+++ b/frictionless/table/row.py
@@ -82,16 +82,12 @@ class Row(Dict[str, Any]):
         return super().__eq__(other)
 
     def __str__(self):
-        s = ""
-        if not self.__processed:
-            s = "Unprocessed: "
-        return s + super().__str__()
+        self.__process()
+        return super().__str__()
 
     def __repr__(self):
-        s = ""
-        if not self.__processed:
-            s = "Unprocessed: "
-        return s + super().__repr__()
+        self.__process()
+        return super().__repr__()
 
     def __setitem__(self, key: str, value: Any):
         try:


### PR DESCRIPTION
Reverts commit b419325c55dff4b169676a730b6193ca3ebcb437

While `extract` was processing the rows, `read_rows` would print rows as "Unprocessed", which is an undesired change.